### PR TITLE
Webserver and yagna autostart

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ setuptools = "*"
 [tool.poetry.scripts]
 ray-on-golem = "ray_on_golem.server.run:main"
 
-
 [tool.poetry.group.dev.dependencies]
 poethepoet = "^0.22.0"
 

--- a/ray_on_golem/server/models.py
+++ b/ray_on_golem/server/models.py
@@ -14,6 +14,12 @@ class NodeState(Enum):
     stopping = "stopping"
 
 
+class ShutdownState(Enum):
+    NOT_ENABLED = "not_enabled"
+    CLUSTER_NOT_EMPTY = "cluster_not_empty"
+    WILL_SHUTDOWN = "will_shutdown"
+
+
 class Node(BaseModel):
     node_id: NodeId
     state: NodeState
@@ -103,3 +109,11 @@ class GetOrCreateDefaultSshKeyRequestData(BaseModel):
 
 class GetOrCreateDefaultSshKeyResponseData(BaseModel):
     ssh_key_base64: str
+
+
+class SelfShutdownRequestData(BaseModel):
+    pass
+
+
+class SelfShutdownResponseData(BaseModel):
+    shutdown_state: ShutdownState

--- a/ray_on_golem/server/services/golem/golem.py
+++ b/ray_on_golem/server/services/golem/golem.py
@@ -85,9 +85,9 @@ class GolemService:
         """
         await self.payment_manager.terminate_agreements()
 
-        logger.info(f"----- Waiting for all invoices...")
+        logger.info(f"Waiting for all invoices...")
         await self.payment_manager.wait_for_invoices()
-        logger.info(f"----- All invoices paid")
+        logger.info(f"Waiting for all invoices done")
 
         await self._golem.aclose()
         self._golem = None

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -38,6 +38,10 @@ class RayService:
         await self._stop_head_node_to_webserver_tunel()
 
         async with self._nodes_lock:
+            if not self._nodes:
+                logger.info(f"No need to destroy activities, as no activities are running")
+                return
+
             logger.info(f"Destroying {len(self._nodes)} activities...")
 
             for node in self._nodes.values():

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -112,8 +112,13 @@ class RayService:
 
             return {node.node_id: node.dict(exclude={"activity"})}
 
-    async def get_non_terminated_nodes_ids(self, tags_to_match: Dict[str, str]) -> List[NodeId]:
+    async def get_non_terminated_nodes_ids(
+        self, tags_to_match: Optional[Dict[str, str]] = None
+    ) -> List[NodeId]:
         async with self._nodes_lock:
+            if tags_to_match is None:
+                return list(self._nodes.keys())
+
             return [
                 node_id
                 for node_id, node in self._nodes.items()

--- a/ray_on_golem/server/services/yagna.py
+++ b/ray_on_golem/server/services/yagna.py
@@ -15,7 +15,7 @@ from ray_on_golem.utils import run_subprocess
 logger = logging.getLogger(__name__)
 
 YAGNA_APPNAME = "ray-on-golem"
-YAGNA_API_URL = URL('http://127.0.0.1:7465')
+YAGNA_API_URL = URL("http://127.0.0.1:7465")
 
 
 class YagnaServiceError(RayOnGolemError):
@@ -67,10 +67,12 @@ class YagnaService:
         return True
 
     async def _run_yagna_service(self):
-        logger.info('Starting Yagna service...')
+        logger.info("Starting Yagna service...")
 
         process = await asyncio.create_subprocess_exec(
-            self._yagna_path, "service", "run",
+            self._yagna_path,
+            "service",
+            "run",
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.DEVNULL,
         )
@@ -79,23 +81,23 @@ class YagnaService:
 
         if is_running:
             self._yagna_process = process
-            logger.info('Starting Yagna service done')
+            logger.info("Starting Yagna service done")
         else:
-            logger.error('Starting Yagna service failed!')
+            logger.error("Starting Yagna service failed!")
 
     async def _stop_yagna_service(self):
         if self._yagna_process is None:
-            logger.info('No need to stop Yagna service, as it was ran externally')
+            logger.info("No need to stop Yagna service, as it was ran externally")
             return
 
-        logger.info('Stopping Yagna service...')
+        logger.info("Stopping Yagna service...")
 
         if self._yagna_process.returncode is None:
             self._yagna_process.terminate()
 
         await self._yagna_process.wait()
 
-        logger.info('Stopping Yagna service done')
+        logger.info("Stopping Yagna service done")
 
     async def _get_or_create_yagna_appkey(self):
         if YAGNA_APPKEY:

--- a/ray_on_golem/server/services/yagna.py
+++ b/ray_on_golem/server/services/yagna.py
@@ -5,6 +5,9 @@ from asyncio.subprocess import Process
 from pathlib import Path
 from typing import Optional
 
+import aiohttp
+from yarl import URL
+
 from ray_on_golem.exceptions import RayOnGolemError
 from ray_on_golem.server.settings import YAGNA_APPKEY
 from ray_on_golem.utils import run_subprocess
@@ -12,6 +15,7 @@ from ray_on_golem.utils import run_subprocess
 logger = logging.getLogger(__name__)
 
 YAGNA_APPNAME = "ray-on-golem"
+YAGNA_API_URL = URL('http://127.0.0.1:7465')
 
 
 class YagnaServiceError(RayOnGolemError):
@@ -26,23 +30,18 @@ class YagnaService:
         self._yagna_process: Optional[Process] = None
 
     async def init(self) -> None:
-        self.yagna_appkey = await self._get_or_create_yagna_appkey()
-
         if await self._check_if_yagna_is_running():
             logger.info("Yagna service is already running")
         else:
             await self._run_yagna_service()
+            await self._run_yagna_payment_fund()  # FIXME
+
+        self.yagna_appkey = await self._get_or_create_yagna_appkey()
 
     async def shutdown(self):
-        if self._yagna_process is None:
-            return
+        await self._stop_yagna_service()
 
-        if self._yagna_process.returncode is None:
-            self._yagna_process.terminate()
-
-        await self._yagna_process.wait()
-
-    async def _wait_for_yagna(self) -> bool:
+    async def _wait_for_yagna_api(self) -> bool:
         for _ in range(25):
             if await self._check_if_yagna_is_running():
                 return True
@@ -53,11 +52,11 @@ class YagnaService:
 
     async def _check_if_yagna_is_running(self) -> bool:
         try:
-            await run_subprocess(self._yagna_path, "id", "show")
-        except RayOnGolemError:
+            async with aiohttp.ClientSession() as client:
+                async with client.get(YAGNA_API_URL):
+                    return True
+        except aiohttp.ClientError:
             return False
-
-        return True
 
     async def _run_yagna_payment_fund(self) -> bool:
         try:
@@ -68,14 +67,35 @@ class YagnaService:
         return True
 
     async def _run_yagna_service(self):
-        process = await asyncio.create_subprocess_exec(self._yagna_path, "service", "run")
+        logger.info('Starting Yagna service...')
 
-        is_running = await self._wait_for_yagna()
+        process = await asyncio.create_subprocess_exec(
+            self._yagna_path, "service", "run",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+        is_running = await self._wait_for_yagna_api()
 
         if is_running:
             self._yagna_process = process
+            logger.info('Starting Yagna service done')
         else:
-            logger.error("Failed to start yagna!")
+            logger.error('Starting Yagna service failed!')
+
+    async def _stop_yagna_service(self):
+        if self._yagna_process is None:
+            logger.info('No need to stop Yagna service, as it was ran externally')
+            return
+
+        logger.info('Stopping Yagna service...')
+
+        if self._yagna_process.returncode is None:
+            self._yagna_process.terminate()
+
+        await self._yagna_process.wait()
+
+        logger.info('Stopping Yagna service done')
 
     async def _get_or_create_yagna_appkey(self):
         if YAGNA_APPKEY:

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -1,6 +1,11 @@
 import os
 from pathlib import Path
 
+RAY_ON_GOLEM_PATH = Path(os.getenv("RAY_ON_GOLEM_PATH", "ray-on-golem"))
+YAGNA_PATH = Path(os.getenv("YAGNA_PATH", "yagna"))
+WEBSOCAT_PATH = Path(os.getenv("WEBSOCAT_PATH", "websocat"))
+TMP_PATH = Path("/tmp/ray_on_golem")
+
 LOGGING_CONFIG = {
     "version": 1,
     "disable_existing_loggers": True,
@@ -9,34 +14,34 @@ LOGGING_CONFIG = {
             "class": "logging.StreamHandler",
             "level": "DEBUG",
             "formatter": "standard",
-        }
+        },
+        "file": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "level": "DEBUG",
+            "formatter": "standard",
+            "filename": TMP_PATH / "webserver.log",
+            "maxBytes": 1024 * 1024,  # 1MB
+            "backupCount": 3,
+        },
     },
     "formatters": {
         "standard": {
             "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         },
     },
+    "root": {
+        "level": "INFO",
+        "handlers": ["console", "file"],
+    },
     "loggers": {
-        "root": {
-            "handlers": ["console"],
-            "level": "INFO",
-        },
         "aiohttp": {
-            "handlers": ["console"],
             "level": "DEBUG",
-            "propagate": False,
         },
         "ray_on_golem": {
-            "handlers": ["console"],
             "level": "INFO",
-            "propagate": False,
         },
     },
 }
-
-YAGNA_PATH = Path(os.getenv("YAGNA_PATH", "yagna"))
-WEBSOCAT_PATH = Path(os.getenv("WEBSOCAT_PATH", "websocat"))
-TMP_PATH = Path("/tmp/ray_on_golem")
 
 YAGNA_APPKEY = os.getenv("YAGNA_APPKEY")
 RAY_ON_GOLEM_SERVER_PORT = int(os.getenv("RAY_ON_GOLEM_SERVER_PORT", 4578))
@@ -53,3 +58,4 @@ URL_CREATE_NODES = "/create_nodes"
 URL_TERMINATE_NODE = "/terminate"
 URL_GET_SSH_PROXY_COMMAND = "/ssh_proxy_command"
 URL_GET_OR_CREATE_DEFAULT_SSH_KEY = "/ger_or_create_default_ssh_key"
+URL_SELF_SHUTDOWN = "/self_shutdown"

--- a/ray_on_golem/utils.py
+++ b/ray_on_golem/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import os
 from asyncio.subprocess import Process
 from pathlib import Path
 from typing import Dict, Optional
@@ -31,6 +32,10 @@ def are_dicts_equal(dict1: Dict, dict2: Dict) -> bool:
     return True
 
 
+def is_running_on_golem_network() -> bool:
+    return os.getenv("ON_GOLEM_NETWORK") is not None
+
+
 def get_default_ssh_key_name(cluster_name: str) -> str:
     return "ray_on_golem_rsa_{}".format(hashlib.md5(cluster_name.encode()).hexdigest()[:10])
 
@@ -56,12 +61,10 @@ async def start_ssh_reverse_tunel_process(
 
     command_parts.append(f"root@{remote_host}")
 
-    # FIXME: Use subprocess running from ray-on-golem's utils
     process = await asyncio.create_subprocess_shell(
         " ".join(command_parts),
-        stderr=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stdin=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.DEVNULL,
     )
 
     return process


### PR DESCRIPTION
What I've done:
- Upgraded yagna autostart/stop in webserver - yagna is checked / started at webserver start, and stopped at webserver stop (if yagna was managed by webserver in the first place)
- Enabled auto `yagna payment fund`, as its required each time after yagna restart, due to usage of goerli instead of rinkeby
- Upgraded a little logs of few things to have them more explicit
- Upgraded webserver autostart/stop in node provider - webserver is checked at before any webserver call, started if needed, and stopped after all nodes are terminated
- Reformatted the code

Notable remarks:
- Auto `yagna payment fund` should be tested / changed while using mainnet, as the is no reason to force the user to wait to collect testnet funds
- As node provider is used by ray only for atomic cluster actions, we have no control over `up` and `down` commands, hence we don't know the true intent. This arises in webserver stopping, node termination is not a last commands that is ran at `down`. I've assumed that 10s delay from 