### PR TITLE
Dev cluster config

### DIFF
--- a/golem-cluster-dev.yaml
+++ b/golem-cluster-dev.yaml
@@ -16,6 +16,8 @@ provider:
     # Port of golem webserver that has connection with golem network
     webserver_port: 4578
 
+    enable_registry_stats: false
+
     # Blockchain used for payments.
     # Goerli means running free nodes on testnet,
     # Polygon is for mainnet operations.
@@ -39,8 +41,11 @@ provider:
       min_storage_gib: 0
 
 # The files or directories to copy to the head and worker nodes
-# file_mounts:
-  # <remote_path>: <local_path>
+file_mounts:
+  # remote_path: local_path
+  {
+    "/app/ray_on_golem": "./ray_on_golem",
+  }
 
 # Tells the autoscaler the allowed node types and the resources they provide
 available_node_types:

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -35,11 +35,15 @@ class RayService:
         self._ssh_public_key_path: Optional[Path] = None
 
     async def shutdown(self) -> None:
+        logger.info("Stopping RayService...")
+
         await self._stop_head_node_to_webserver_tunel()
 
         async with self._nodes_lock:
             if not self._nodes:
-                logger.info(f"No need to destroy activities, as no activities are running")
+                logger.info(
+                    "Stopping RayService done, no need to destroy activities, as no activities are running"
+                )
                 return
 
             logger.info(f"Destroying {len(self._nodes)} activities...")
@@ -50,6 +54,8 @@ class RayService:
             logger.info(f"Destroying {len(self._nodes)} activities done")
 
             self._nodes.clear()
+
+        logger.info("Stopping RayService done")
 
     async def create_cluster_on_golem(self, provider_config: CreateClusterRequestData) -> None:
         self._ssh_private_key_path = Path(provider_config.ssh_private_key)

--- a/ray_on_golem/server/services/yagna.py
+++ b/ray_on_golem/server/services/yagna.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 from asyncio.subprocess import Process
 from pathlib import Path
 from typing import Optional
@@ -65,6 +66,7 @@ class YagnaService:
             "run",
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.DEVNULL,
+            preexec_fn=os.setpgrp,  # https://stackoverflow.com/a/5446982/1993670
         )
 
         is_running = await self._wait_for_yagna_api()

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -11,7 +11,7 @@ TMP_PATH = Path("/tmp/ray_on_golem")
 
 LOGGING_CONFIG = {
     "version": 1,
-    "disable_existing_loggers": True,
+    "disable_existing_loggers": False,
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",

--- a/ray_on_golem/server/views.py
+++ b/ray_on_golem/server/views.py
@@ -1,12 +1,12 @@
 import asyncio
 import logging
-import sys
 
 from aiohttp import web
 
 from ray_on_golem.server import models, settings
 from ray_on_golem.server.models import ShutdownState
 from ray_on_golem.server.services import RayService
+from ray_on_golem.utils import raise_graceful_exit
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +187,7 @@ async def self_shutdown(request):
         shutdown_seconds = int(settings.RAY_ON_GOLEM_SHUTDOWN_DELAY.total_seconds())
         logger.info(f"Received a self-shutdown request, exiting in {shutdown_seconds} seconds...")
         loop = asyncio.get_event_loop()
-        loop.call_later(shutdown_seconds, sys.exit)
+        loop.call_later(shutdown_seconds, raise_graceful_exit)
 
     response_data = models.SelfShutdownResponseData(shutdown_state=shutdown_state)
 

--- a/ray_on_golem/utils.py
+++ b/ray_on_golem/utils.py
@@ -5,6 +5,8 @@ from asyncio.subprocess import Process
 from pathlib import Path
 from typing import Dict, Optional
 
+from aiohttp.web_runner import GracefulExit
+
 from ray_on_golem.exceptions import RayOnGolemError
 
 
@@ -68,3 +70,7 @@ async def start_ssh_reverse_tunel_process(
     )
 
     return process
+
+
+def raise_graceful_exit() -> None:
+    raise GracefulExit()


### PR DESCRIPTION
What I've done:
- Created `golem-cluster-dev.yaml` file, with disabled registry stats and enabled project files sync
- Cleaned up some fields in cluster yaml files
- Added support for disabling registry stats on image resolution
- Added default value for `auth/ssh_user` field
- Fixed problem with `disable_existing_loggers` settings in logging facility, that made bunch of premature exit problems invisible
- Fixed problem with premature exit of managed yagna process due to `SIGINT` forwarding from parent to child subprocess, that made problems with clean `GolemNode` shutdown
- Fixed problem with premature webserver exit on self-shutdown, that made final exit logs not reachable
- Added more verbose logs of service lifetime
- Reformatted code

Notable remarks:
- Forcibly exiting webserver can leave `yagna` process running in the background
- Terminating nodes with `ray down` can have race condition with autoscaler in the background, and webserver self-shutdown can be called multiple times, exiting too early in result, witch raises ugly exception on `ray down`