### PR TITLE
Better subprocesses logs

### DIFF
--- a/examples/dds-with-ray.py
+++ b/examples/dds-with-ray.py
@@ -4,7 +4,12 @@ import ray
 
 DEAL_COUNT = 50
 # endplay library dependency
-runtime_env = {"pip": ["endplay==0.4.11b0"]}
+runtime_env = {
+    "pip": [
+        "Pillow",  # explicit uppercased "Pillow", as pip complains about mismatched metadata in endplay dependency tree
+        "endplay",
+    ]
+}
 
 # Use default ray cluster or start a local one
 # Make sure endplay lib is installed

--- a/examples/dds-with-ray.py
+++ b/examples/dds-with-ray.py
@@ -7,7 +7,7 @@ DEAL_COUNT = 50
 runtime_env = {
     "pip": [
         "Pillow",  # explicit uppercased "Pillow", as pip complains about mismatched metadata in endplay dependency tree
-        "endplay",
+        "endplay==0.4.11b0",
     ]
 }
 

--- a/ray_on_golem/server/exceptions.py
+++ b/ray_on_golem/server/exceptions.py
@@ -28,7 +28,7 @@ class DestroyActivityError(RayOnGolemServerError):
 
 
 class CheckYagnaStatusError(RayOnGolemServerError):
-    message = "Can't check yagna status"
+    message = "Can't check Yagna status"
 
 
 class ManifestNotFound(RayOnGolemServerError):

--- a/ray_on_golem/server/services/golem/golem.py
+++ b/ray_on_golem/server/services/golem/golem.py
@@ -317,15 +317,15 @@ class GolemService:
         }
 
         for cost_field_name, coef_field_name in field_names.items():
-            cost_max_value = getattr(node_config.cost_management, cost_field_name)
+            cost_max_value = getattr(node_config.cost_management, cost_field_name, None)
             if cost_max_value is not None:
-                stack.extra_proposal_plugins.append(
+                proposal_plugins.append(
                     RejectIfCostsExceeds(cost_max_value, LinearCoeffsCost(coef_field_name)),
                 )
 
         if proposal_plugins:
-            logger.debug("Cost management based on max limits applied")
             stack.extra_proposal_plugins.extend(proposal_plugins)
+            logger.debug("Cost management based on max limits applied")
         else:
             logger.debug("Cost management based on max limits is not enabled")
 

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -8,6 +8,9 @@ RAY_ON_GOLEM_PATH = Path(os.getenv("RAY_ON_GOLEM_PATH", "ray-on-golem"))
 YAGNA_PATH = Path(os.getenv("YAGNA_PATH", "yagna"))
 WEBSOCAT_PATH = Path(os.getenv("WEBSOCAT_PATH", "websocat"))
 TMP_PATH = Path("/tmp/ray_on_golem")
+LOGGING_INFO_PATH = TMP_PATH / "webserver.log"
+LOGGING_DEBUG_PATH = TMP_PATH / "webserver_debug.log"
+LOGGING_YAGNA_PATH = TMP_PATH / "yagna.log"
 
 LOGGING_CONFIG = {
     "version": 1,
@@ -18,7 +21,10 @@ LOGGING_CONFIG = {
         },
     },
     "formatters": {
-        "standard": {
+        "compact": {
+            "format": "[%(asctime)s] [%(levelname)-7s] [%(name)s] %(message)s",
+        },
+        "verbose": {
             "format": "[%(asctime)s] [%(levelname)-7s] [%(traceid)s] "
             "[%(name)s:%(lineno)d] %(message)s",
         },
@@ -27,17 +33,15 @@ LOGGING_CONFIG = {
         "console": {
             "class": "logging.StreamHandler",
             "level": "DEBUG",
-            "formatter": "standard",
+            "formatter": "verbose",
             "filters": ["add_trace_id"],
         },
         "file": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "level": "DEBUG",
-            "formatter": "standard",
-            "filters": ["add_trace_id"],
-            "filename": TMP_PATH / "webserver.log",
-            "maxBytes": 1024 * 1024,  # 1MB
-            "backupCount": 3,
+            "class": "logging.FileHandler",
+            "level": "INFO",
+            "formatter": "compact",
+            "filename": LOGGING_INFO_PATH,
+            "mode": "w",
         },
     },
     "root": {
@@ -49,34 +53,39 @@ LOGGING_CONFIG = {
     },
     "loggers": {
         "aiohttp": {
-            "level": "WARNING",
+            "level": "DEBUG",
+            "handlers": ["console"],
+            "propagate": False,
         },
         "ray_on_golem": {
-            "level": "INFO",
+            "level": "DEBUG",
         },
         "golem": {
             "level": "INFO",
         },
+        "golem.utils.asyncio": {
+            "level": "DEBUG",
+        },
         "golem.managers.payment": {
-            "level": "INFO",
+            "level": "DEBUG",
         },
         "golem.managers.network": {
-            "level": "INFO",
+            "level": "DEBUG",
         },
         "golem.managers.demand": {
-            "level": "INFO",
+            "level": "DEBUG",
         },
         "golem.managers.proposal": {
-            "level": "INFO",
+            "level": "DEBUG",
         },
         "golem.managers.agreement": {
-            "level": "INFO",
+            "level": "DEBUG",
         },
         "golem.managers.activity": {
-            "level": "INFO",
+            "level": "DEBUG",
         },
         "golem.managers.work": {
-            "level": "INFO",
+            "level": "DEBUG",
         },
     },
 }
@@ -84,10 +93,13 @@ LOGGING_CONFIG = {
 YAGNA_APPKEY = os.getenv("YAGNA_APPKEY")
 YAGNA_APPNAME = os.getenv("YAGNA_APPNAME", "ray-on-golem")
 YAGNA_API_URL = URL(os.getenv("YAGNA_API_URL", "http://127.0.0.1:7465"))
+YAGNA_START_DEADLINE = timedelta(minutes=2)
+YAGNA_CHECK_DEADLINE = timedelta(seconds=2)
 
-RAY_ON_GOLEM_START_DEADLINE = timedelta(minutes=2)
+RAY_ON_GOLEM_START_DEADLINE = timedelta(minutes=2, seconds=30)
 RAY_ON_GOLEM_CHECK_DEADLINE = timedelta(seconds=2)
 RAY_ON_GOLEM_SHUTDOWN_DELAY = timedelta(seconds=10)
+RAY_ON_GOLEM_SHUTDOWN_DEADLINE = timedelta(seconds=30)
 
 URL_HEALTH_CHECK = "/health_check"
 URL_CREATE_CLUSTER = "/create_cluster"


### PR DESCRIPTION
What I've done:
- Reworked logging for subprocesses (webserver/yagna), following of the @shadeofblue idea:
  - stdout/stderr is redirected to debug file
  - If subprocess fail to start, last 50 lines of the log are printed to the user with mentioned file path to see full log.
- Made webserver to log with debug to console, and log with info to file
- Removed unneeded `log_level` parameter, as logs gathered intentionally unconditionally
- Fixed bug in `GolemService._apply_cost_management_hard_limits` that produced wrong log messages by applying plugins too early
- Added explicit guard if ray tried to spawn nodes before cluster bootstrap (happens if there are some leftovers from last webserver instance and its forceful exit)
- Reworded few logs
- Fixed problem with metadata missmatch in pip while installing Pillow package in `dds-with-ray.py` example.

Notable remarks:
- Redirecting stdout of the process to file is most reliable way to see debugs logs, as all non logging facility quirks are printed there (same for python and even yagna!)
- Having webserver to log with debug to console, and log with info to file is a great settlement between explicitly running webserver in development and implicitly running webserver by user