### PR TITLE
Binary dependencies and dynamic ray head ip

### DIFF
--- a/golem-cluster-dev.yaml
+++ b/golem-cluster-dev.yaml
@@ -109,7 +109,7 @@ head_start_ray_commands: [
 
 # Command to start ray on worker nodes. You don't need to change this.
 worker_start_ray_commands: [
-  "ray start --address 192.168.0.3:6379",
+  "ray start --address $RAY_HEAD_IP:6379",
 ]
 
 # Authentication credentials that Ray will use to launch nodes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ aiohttp = "^3"
 requests = "^2"
 click = "^8"
 pydantic = "<2"
+websocat = "^1.12.0"
+golem-node = "0.12.2"
 
 setuptools = "*"
 

--- a/ray_on_golem/provider/node_provider.py
+++ b/ray_on_golem/provider/node_provider.py
@@ -212,20 +212,25 @@ class GolemNodeProvider(NodeProvider):
                         cli_logger.print("Starting webserver done")
                         return
                 else:
-                    cli_logger.abort(
-                        "Starting webserver failed!\nShowing last 50 lines from `{}`:\n{}",
-                        LOGGING_DEBUG_PATH,
-                        "".join(LOGGING_DEBUG_PATH.open("r").readlines()[-50:]),
-                    )
+                    with LOGGING_DEBUG_PATH.open("r") as file:
+                        cli_logger.abort(
+                            "Starting webserver failed!\nShowing last 50 lines from `{}`:\n{}",
+                            LOGGING_DEBUG_PATH,
+                            "".join(file.readlines()[-50:]),
+                        )
 
                 cli_logger.print(
                     "Webserver is not yet running, waiting additional `{}` seconds...",
                     check_seconds,
                 )
 
-            cli_logger.abort(
-                "Starting webserver failed! Deadline of `{}` reached.", RAY_ON_GOLEM_START_DEADLINE
-            )
+            with LOGGING_DEBUG_PATH.open("r") as file:
+                cli_logger.abort(
+                    "Starting webserver failed! Deadline of `{}` reached.\nShowing last 50 lines from `{}`:\n{}",
+                    RAY_ON_GOLEM_START_DEADLINE,
+                    LOGGING_DEBUG_PATH,
+                    "".join(file.readlines()[-50:]),
+                )
 
     @staticmethod
     def _stop_webserver(ray_on_golem_client: RayOnGolemClient) -> None:

--- a/ray_on_golem/server/services/yagna.py
+++ b/ray_on_golem/server/services/yagna.py
@@ -100,11 +100,12 @@ class YagnaService:
                     logger.info("Starting Yagna done")
                     return
             else:
-                logger.error(
-                    "Starting Yagna failed!\nShowing last 50 lines from `%s`:\n%s",
-                    LOGGING_YAGNA_PATH,
-                    "".join(LOGGING_YAGNA_PATH.open("r").readlines()[-50:]),
-                )
+                with LOGGING_YAGNA_PATH.open("r") as file:
+                    logger.error(
+                        "Starting Yagna failed!\nShowing last 50 lines from `%s`:\n%s",
+                        LOGGING_YAGNA_PATH,
+                        "".join(file.readlines()[-50:]),
+                    )
                 raise YagnaServiceError("Starting Yagna failed!")
 
             logger.info(
@@ -112,12 +113,13 @@ class YagnaService:
                 check_seconds,
             )
 
-        logger.error(
-            "Starting Yagna failed! Deadline of `%s` reached.\nShowing last 50 lines from `%s`:\n%s",
-            YAGNA_START_DEADLINE,
-            LOGGING_YAGNA_PATH,
-            "".join(LOGGING_YAGNA_PATH.open("r").readlines()[-50:]),
-        )
+        with LOGGING_YAGNA_PATH.open("r") as file:
+            logger.error(
+                "Starting Yagna failed! Deadline of `%s` reached.\nShowing last 50 lines from `%s`:\n%s",
+                YAGNA_START_DEADLINE,
+                LOGGING_YAGNA_PATH,
+                "".join(file.readlines()[-50:]),
+            )
         raise YagnaServiceError("Starting Yagna failed!")
 
     async def _on_yagna_early_exit(self) -> None:

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -96,7 +96,7 @@ YAGNA_API_URL = URL(os.getenv("YAGNA_API_URL", "http://127.0.0.1:7465"))
 YAGNA_START_DEADLINE = timedelta(minutes=2)
 YAGNA_CHECK_DEADLINE = timedelta(seconds=2)
 
-RAY_ON_GOLEM_START_DEADLINE = timedelta(minutes=2, seconds=30)
+RAY_ON_GOLEM_START_DEADLINE = timedelta(minutes=5)
 RAY_ON_GOLEM_CHECK_DEADLINE = timedelta(seconds=2)
 RAY_ON_GOLEM_SHUTDOWN_DELAY = timedelta(seconds=10)
 RAY_ON_GOLEM_SHUTDOWN_DEADLINE = timedelta(seconds=30)

--- a/ray_on_golem/utils.py
+++ b/ray_on_golem/utils.py
@@ -36,7 +36,7 @@ async def run_subprocess_output(*args) -> bytes:
     stdout, stderr = await process.communicate()
 
     if process.returncode != 0:
-        raise RayOnGolemError(stderr)
+        raise RayOnGolemError(f'Process exited with code `{process.returncode}`!\nstdout:\n{stdout}\nstderr:\n{stderr}')
 
     return stdout
 


### PR DESCRIPTION
What I've done:
- Added `yagna` and `websocat` python dependencies. As `yagna` is more version dependent, exact value is pinned
- Changed cluster yaml to use `$RAY_HEAD_IP` env variable (prepared by autoscaler alone)
- Minor log enchancements

Notable remarks:
- Last time we've tried using `$RAY_HEAD_IP` env variable it was not working, probably because of old approach with head on local machine. Now, it just works out of the box, duh.