### PR TITLE
Rename counters and adjust params for network stats

### DIFF
--- a/ray_on_golem/network_stats/services/network_stats.py
+++ b/ray_on_golem/network_stats/services/network_stats.py
@@ -216,10 +216,10 @@ class NetworkStatsService:
                     proposal_scorers=(*stack.extra_proposal_scorers.values(),),
                     update_interval=timedelta(seconds=10),
                 ),
-                self._stats_plugin_factory.create_counter_plugin("Scored"),
+                self._stats_plugin_factory.create_counter_plugin("Negotiation initialized"),
                 self._stats_plugin_factory.create_negotiating_plugin(),
-                self._stats_plugin_factory.create_counter_plugin("Negotiated"),
-                Buffer(min_size=1, max_size=50, fill_concurrency_size=10),
+                self._stats_plugin_factory.create_counter_plugin("Negotiated successfully"),
+                Buffer(min_size=1, max_size=50, fill_concurrency_size=8),
             ]
         )
         stack.proposal_manager = DefaultProposalManager(

--- a/ray_on_golem/network_stats/services/network_stats.py
+++ b/ray_on_golem/network_stats/services/network_stats.py
@@ -210,7 +210,7 @@ class NetworkStatsService:
         plugins.extend(
             [
                 ScoringBuffer(
-                    min_size=50,
+                    min_size=500,
                     max_size=1000,
                     fill_at_start=True,
                     proposal_scorers=(*stack.extra_proposal_scorers.values(),),
@@ -219,7 +219,7 @@ class NetworkStatsService:
                 self._stats_plugin_factory.create_counter_plugin("Negotiation initialized"),
                 self._stats_plugin_factory.create_negotiating_plugin(),
                 self._stats_plugin_factory.create_counter_plugin("Negotiated successfully"),
-                Buffer(min_size=1, max_size=50, fill_concurrency_size=8),
+                Buffer(min_size=800, max_size=1000, fill_concurrency_size=16),
             ]
         )
         stack.proposal_manager = DefaultProposalManager(

--- a/utils/apply_overrides.py
+++ b/utils/apply_overrides.py
@@ -1,7 +1,8 @@
 import argparse
+import sys
 from pathlib import Path
 from typing import Final
-import sys
+
 import yaml
 
 from .yaml import load_yamls


### PR DESCRIPTION
New example output of the `ray-on-golem network-stats`
```
$ ray-on-golem network-stats golem-cluster.dev.yaml -d 1
Gathering stats data for 1 minutes...
Gathering stats data done

Proposals count:
Initial: 66
Not blacklisted: 66
Passed Reject if max_average_usage_cost exceeds 1.5: 66
Passed Reject if price_initial exceeds 0.5: 66
Passed Reject if price_cpu_sec exceeds 0.0005: 66
Passed Reject if price_duration_sec exceeds 0.0005: 66
Negotiation initialized: 64
Negotiated successfully: 26

Negotiation errors:
Failed to send proposal response! Request timed out: 31
Failed to send proposal response! 500: {"message":"Failed to send response for Proposal [***]. Error: Countering Proposal [***] GSB error: GSB failure: Net: error forwarding message: Socket closed.."}: 2
No capacity available. Reached Agreements limit: 1: 1
```