### PR TITLE
Onboarding message on mainnet

### DIFF
--- a/ray_on_golem/client/client.py
+++ b/ray_on_golem/client/client.py
@@ -6,6 +6,7 @@ from yarl import URL
 
 from ray_on_golem.client.exceptions import RayOnGolemClientError, RayOnGolemClientValidationError
 from ray_on_golem.server import models, settings
+from ray_on_golem.server.models import CreateClusterResponseData
 
 TResponseModel = TypeVar("TResponseModel")
 
@@ -19,11 +20,11 @@ class RayOnGolemClient:
     def create_cluster(
         self,
         cluster_config: Dict[str, Any],
-    ) -> None:
-        self._make_request(
+    ) -> CreateClusterResponseData:
+        return self._make_request(
             url=settings.URL_CREATE_CLUSTER,
             request_data=models.CreateClusterRequestData(**cluster_config),
-            response_model=models.EmptyResponseData,
+            response_model=models.CreateClusterResponseData,
             error_message="Couldn't create cluster",
         )
 

--- a/ray_on_golem/provider/node_provider.py
+++ b/ray_on_golem/provider/node_provider.py
@@ -30,7 +30,14 @@ from ray_on_golem.utils import (
 )
 
 LOG_GROUP = "Ray On Golem"
-MAINNET_PAYMENT_NETWORKS = ("mainnet", "polygon",)
+
+PAYMENT_NETWORK_MAINNET = "mainnet"
+PAYMENT_NETWORK_POLYGON = "polygon"
+
+ONBOARDING_MESSAGE = {
+    PAYMENT_NETWORK_MAINNET: "Running Ray on Golem on the Ethereum Mainnet requires GLM and ETH tokens.",
+    PAYMENT_NETWORK_POLYGON: "Running Ray on Golem on the mainnet requires GLM and MATIC tokens on the Polygon blockchain (see: https://docs.golem.network/docs/creators/ray/mainnet).",
+}
 
 logger = logging.getLogger(__name__)
 
@@ -322,16 +329,13 @@ class GolemNodeProvider(NodeProvider):
             cli_logger.print("Requesting webserver shutdown done, will stop soon")
 
     def _print_mainnet_onboarding_message(self, yagna_payment_status_output: str) -> None:
-        if self._payment_network not in MAINNET_PAYMENT_NETWORKS:
+        if self._payment_network not in ONBOARDING_MESSAGE:
             return
 
         cli_logger.newline()
 
         with cli_logger.indented():
-            cli_logger.print(
-                "Running Ray on Golem on the mainnet requires GLM and MATIC tokens on the Polygon blockchain"
-                " (see: https://docs.golem.network/docs/creators/ray/mainnet)."
-            )
+            cli_logger.print(ONBOARDING_MESSAGE.get(self._payment_network))
             cli_logger.print("Your wallet:")
 
             with cli_logger.indented():

--- a/ray_on_golem/provider/node_provider.py
+++ b/ray_on_golem/provider/node_provider.py
@@ -29,8 +29,10 @@ from ray_on_golem.utils import (
     prepare_tmp_dir,
 )
 
-logger = logging.getLogger(__name__)
 LOG_GROUP = "Ray On Golem"
+MAINNET_PAYMENT_NETWORKS = ("mainnet", "polygon",)
+
+logger = logging.getLogger(__name__)
 
 
 class GolemNodeProvider(NodeProvider):
@@ -48,7 +50,16 @@ class GolemNodeProvider(NodeProvider):
         provider_parameters = {
             ssh_arg_mapping.get(k) or k: v for k, v in provider_parameters.items()
         }
-        self._ray_on_golem_client.create_cluster(provider_parameters)
+        self._payment_network = provider_parameters["payment_network"].lower().strip()
+
+        cluster_creation_response = self._ray_on_golem_client.create_cluster(provider_parameters)
+
+        self._wallet_address = cluster_creation_response.wallet_address
+        self._is_cluster_just_created = cluster_creation_response.is_cluster_just_created
+
+        self._print_mainnet_onboarding_message(
+            cluster_creation_response.yagna_payment_status_output
+        )
 
     @classmethod
     def bootstrap_config(cls, cluster_config: Dict[str, Any]) -> Dict[str, Any]:
@@ -309,3 +320,27 @@ class GolemNodeProvider(NodeProvider):
                 return
 
             cli_logger.print("Requesting webserver shutdown done, will stop soon")
+
+    def _print_mainnet_onboarding_message(self, yagna_payment_status_output: str) -> None:
+        if self._payment_network not in MAINNET_PAYMENT_NETWORKS:
+            return
+
+        cli_logger.newline()
+
+        with cli_logger.indented():
+            cli_logger.print(
+                "Running Ray on Golem on the mainnet requires GLM and MATIC tokens on the Polygon blockchain"
+                " (see: https://docs.golem.network/docs/creators/ray/mainnet)."
+            )
+            cli_logger.print("Your wallet:")
+
+            with cli_logger.indented():
+                for line in yagna_payment_status_output.splitlines():
+                    cli_logger.print(line)
+
+            cli_logger.newline()
+            cli_logger.print(
+                "You can use the Golem Onboarding portal to top up: https://golemfactory.github.io"
+                f"/onboarding_production/?yagnaAddress={self._wallet_address}"
+            )
+            cli_logger.newline()

--- a/ray_on_golem/server/main.py
+++ b/ray_on_golem/server/main.py
@@ -85,6 +85,7 @@ def create_application(port: int, self_shutdown: bool, registry_stats: bool) -> 
     app["ray_service"] = RayService(
         ray_on_golem_port=port,
         golem_service=app["golem_service"],
+        yagna_service=app["yagna_service"],
         tmp_path=TMP_PATH,
     )
 

--- a/ray_on_golem/server/models.py
+++ b/ray_on_golem/server/models.py
@@ -92,6 +92,12 @@ class CreateClusterRequestData(ProviderConfigData):
     pass
 
 
+class CreateClusterResponseData(BaseModel):
+    is_cluster_just_created: bool
+    wallet_address: str
+    yagna_payment_status_output: str
+
+
 class NonTerminatedNodesRequestData(BaseModel):
     tags: Tags
 

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -4,7 +4,7 @@ from asyncio.subprocess import Process
 from contextlib import asynccontextmanager
 from functools import partial
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from golem.utils.asyncio import create_task_with_logging
 from golem.utils.logging import get_trace_id_name
@@ -15,6 +15,7 @@ from ray_on_golem.server.exceptions import NodeNotFound
 from ray_on_golem.server.models import Node, NodeData, NodeId, NodeState, ProviderConfigData, Tags
 from ray_on_golem.server.services.golem import GolemService
 from ray_on_golem.server.services.utils import get_ssh_command
+from ray_on_golem.server.services.yagna import YagnaService
 from ray_on_golem.utils import (
     are_dicts_equal,
     get_default_ssh_key_name,
@@ -30,12 +31,20 @@ class RayServiceError(RayOnGolemError):
 
 
 class RayService:
-    def __init__(self, ray_on_golem_port: int, golem_service: GolemService, tmp_path: Path):
+    def __init__(
+        self,
+        ray_on_golem_port: int,
+        golem_service: GolemService,
+        yagna_service: YagnaService,
+        tmp_path: Path,
+    ):
         self._ray_on_golem_port = ray_on_golem_port
         self._golem_service = golem_service
+        self._yagna_service = yagna_service
         self._tmp_path = tmp_path
 
         self._provider_config: Optional[ProviderConfigData] = None
+        self._wallet_address: Optional[str] = None
 
         self._nodes: Dict[NodeId, Node] = {}
         self._nodes_lock = asyncio.Lock()
@@ -57,7 +66,9 @@ class RayService:
 
         logger.info("Stopping RayService done")
 
-    async def create_cluster(self, provider_config: ProviderConfigData) -> None:
+    async def create_cluster(self, provider_config: ProviderConfigData) -> Tuple[bool, str, str]:
+        is_cluster_just_created = self._provider_config is None
+
         self._provider_config = provider_config
 
         # TODO: CALL FUND with payment network and get yagna wallet address
@@ -68,6 +79,14 @@ class RayService:
 
         with self._ssh_public_key_path.open() as f:
             self._ssh_public_key = f.readline().strip()
+
+        await self._yagna_service.run_payment_fund(self._provider_config.payment_network)
+        yagna_output = await self._yagna_service.fetch_payment_status(
+            self._provider_config.payment_network
+        )
+        self._wallet_address = await self._yagna_service.fetch_wallet_address()
+
+        return is_cluster_just_created, self._wallet_address, yagna_output
 
     async def _destroy_nodes(self) -> None:
         async with self._nodes_lock:

--- a/ray_on_golem/server/views.py
+++ b/ray_on_golem/server/views.py
@@ -26,9 +26,17 @@ async def create_cluster(request: web.Request) -> web.Response:
 
     request_data = models.CreateClusterRequestData.parse_raw(await request.text())
 
-    await ray_service.create_cluster(provider_config=request_data)
+    (
+        is_cluster_just_created,
+        wallet_address,
+        yagna_payment_status_output,
+    ) = await ray_service.create_cluster(provider_config=request_data)
 
-    response_data = models.EmptyResponseData()
+    response_data = models.CreateClusterResponseData(
+        is_cluster_just_created=is_cluster_just_created,
+        wallet_address=wallet_address,
+        yagna_payment_status_output=yagna_payment_status_output,
+    )
 
     return web.Response(text=response_data.json())
 


### PR DESCRIPTION
What I've done:
- If `polygon` or `mainnet` is used as `payment_network` in yaml config, onboarding message will be printed at the beginning of the `ray up`.
- `yagna payment fund` is called at create_cluster state, regardless if webserver is managing yagna or not.

Notable remarks:
- We have still problem with allocation exceptions that are not propagating through the stack of managers / background tasks. This is kinda complex, so we need to design neat solution for it.