### PR TITLE
Canceling pending node creation

### DIFF
--- a/golem-cluster.yaml
+++ b/golem-cluster.yaml
@@ -23,7 +23,7 @@ provider:
     #payment_network: "polygon"
 
     # Maximum amount of GLMs that's going to be spent for the whole cluster
-    total_budget: 5
+    total_budget: 500000
 
     node_config:
       # Parameters for golem demands (same for head and workers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ packages = [{include = "ray_on_golem"}]
 python = "^3.8"
 ray = {version="^2.7.1", extras=["default"]}
 # golem-core = { path="../golem-core-python", develop=true }
-# golem-core = { git="https://github.com/golemfactory/golem-core-python.git", branch="main" }
-golem-core = "^0.4.0"
+golem-core = { git="https://github.com/golemfactory/golem-core-python.git", branch="main" }
+#golem-core = "^0.4.0"
 aiohttp = "^3"
 requests = "^2"
 click = "^8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "ray_on_golem"}]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.8.1"
 ray = {version="^2.7.1", extras=["default"]}
 # golem-core = { path="../golem-core-python", develop=true }
 golem-core = { git="https://github.com/golemfactory/golem-core-python.git", branch="main" }

--- a/ray_on_golem/network_stats/services/network_stats.py
+++ b/ray_on_golem/network_stats/services/network_stats.py
@@ -7,14 +7,14 @@ from typing import Dict, Optional, Sequence
 
 from golem.managers import (
     BlacklistProviderIdPlugin,
-    Buffer,
     DefaultProposalManager,
     NegotiatingPlugin,
     PayAllPaymentManager,
     PaymentPlatformNegotiator,
+    ProposalBuffer,
     ProposalManagerPlugin,
+    ProposalScoringBuffer,
     RefreshingDemandManager,
-    ScoringBuffer,
 )
 from golem.managers.base import ProposalNegotiator
 from golem.node import GolemNode
@@ -214,17 +214,17 @@ class NetworkStatsService:
 
         plugins.extend(
             [
-                ScoringBuffer(
+                ProposalScoringBuffer(
                     min_size=500,
                     max_size=1000,
                     fill_at_start=True,
                     proposal_scorers=(*stack.extra_proposal_scorers.values(),),
-                    update_interval=timedelta(seconds=10),
+                    scoring_debounce=timedelta(seconds=10),
                 ),
                 self._stats_plugin_factory.create_counter_plugin("Negotiation initialized"),
                 self._stats_plugin_factory.create_negotiating_plugin(),
                 self._stats_plugin_factory.create_counter_plugin("Negotiated successfully"),
-                Buffer(min_size=800, max_size=1000, fill_concurrency_size=16),
+                ProposalBuffer(min_size=800, max_size=1000, fill_concurrency_size=16),
             ]
         )
         stack.proposal_manager = DefaultProposalManager(

--- a/ray_on_golem/provider/node_provider.py
+++ b/ray_on_golem/provider/node_provider.py
@@ -116,6 +116,13 @@ class GolemNodeProvider(NodeProvider):
 
         return config
 
+    @staticmethod
+    def fillout_available_node_types_resources(cluster_config: Dict[str, Any]) -> Dict[str, Any]:
+        cluster_config.pop("head_node")
+        cluster_config.pop("worker_nodes")
+
+        return cluster_config
+
     @classmethod
     @lru_cache()
     def _get_ray_on_golem_client_instance(cls, webserver_port: int, enable_registry_stats: bool):

--- a/ray_on_golem/server/services/golem/golem.py
+++ b/ray_on_golem/server/services/golem/golem.py
@@ -387,7 +387,12 @@ class GolemService:
         logger.info(f"Creating new activity...")
 
         await add_state_log("[1/9] Getting agreement...")
-        agreement = await stack.agreement_manager.get_agreement()
+
+        try:
+            agreement = await stack.agreement_manager.get_agreement()
+        except Exception as e:
+            logger.error(f"Creating new activity failed with `{e}`")
+            raise RuntimeError(e) from e
 
         proposal = agreement.proposal
         provider_desc = f"{await proposal.get_provider_name()} ({await proposal.get_provider_id()})"
@@ -416,7 +421,8 @@ class GolemService:
             )
 
             await self._network.refresh_nodes()
-        except Exception:
+        except Exception as e:
+            logger.error(f"Creating new activity failed with `{e}`")
             await activity.destroy()
             raise
 

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -6,7 +6,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
-from golem.utils.asyncio import create_task_with_logging
+from golem.utils.asyncio import create_task_with_logging, ensure_cancelled_many
 from golem.utils.logging import get_trace_id_name
 from ray.autoscaler.tags import NODE_KIND_HEAD, TAG_RAY_NODE_KIND
 
@@ -50,6 +50,8 @@ class RayService:
         self._nodes_lock = asyncio.Lock()
         self._nodes_id_counter = 0
 
+        self._create_node_tasks: List[asyncio.Task] = []
+
         self._head_node_to_webserver_tunnel_process: Optional[Process] = None
         self._head_node_to_webserver_tunnel_early_exit_task: Optional[asyncio.Task] = None
 
@@ -62,6 +64,7 @@ class RayService:
         logger.info("Stopping RayService...")
 
         await self._stop_head_node_to_webserver_tunnel()
+        await self._stop_create_node_tasks()
         await self._destroy_nodes()
 
         logger.info("Stopping RayService done")
@@ -131,9 +134,11 @@ class RayService:
                     tags=tags,
                 )
 
-                create_task_with_logging(
-                    self._create_node(node_id),
-                    trace_id=get_trace_id_name(self, f"create-node-{node_id}"),
+                self._create_node_tasks.append(
+                    create_task_with_logging(
+                        self._create_node(node_id),
+                        trace_id=get_trace_id_name(self, f"create-node-{node_id}"),
+                    )
                 )
 
         logger.info(f"Requested {count} nodes")
@@ -142,28 +147,33 @@ class RayService:
         return created_node_ids
 
     async def _create_node(self, node_id: NodeId) -> None:
-        activity, ip, ssh_proxy_command = await self._golem_service.create_activity(
-            node_config=self._provider_config.node_config,
-            public_ssh_key=self._ssh_public_key,
-            ssh_user=self._ssh_user,
-            ssh_private_key_path=self._ssh_private_key_path,
-            total_budget=self._provider_config.total_budget,
-            payment_network=self._provider_config.payment_network,
-            subnet_tag=self._provider_config.subnet_tag,
-            add_state_log=partial(self._add_node_state_log, node_id),
-        )
+        try:
+            activity, ip, ssh_proxy_command = await self._golem_service.create_activity(
+                node_config=self._provider_config.node_config,
+                public_ssh_key=self._ssh_public_key,
+                ssh_user=self._ssh_user,
+                ssh_private_key_path=self._ssh_private_key_path,
+                total_budget=self._provider_config.total_budget,
+                payment_network=self._provider_config.payment_network,
+                subnet_tag=self._provider_config.subnet_tag,
+                add_state_log=partial(self._add_node_state_log, node_id),
+            )
 
-        self._print_ssh_command(ip, ssh_proxy_command, self._ssh_user, self._ssh_private_key_path)
+            self._print_ssh_command(
+                ip, ssh_proxy_command, self._ssh_user, self._ssh_private_key_path
+            )
 
-        async with self._get_node_context(node_id) as node:  # type: Node
-            node.state = NodeState.running
-            node.internal_ip = ip
-            node.ssh_proxy_command = ssh_proxy_command
-            node.activity = activity
+            async with self._get_node_context(node_id) as node:  # type: Node
+                node.state = NodeState.running
+                node.internal_ip = ip
+                node.ssh_proxy_command = ssh_proxy_command
+                node.activity = activity
 
-        # TODO: check if node is a head node
-        if not self._is_head_node_to_webserver_tunnel_running():
-            await self._start_head_node_to_webserver_tunnel()
+            # TODO: check if node is a head node
+            if not self._is_head_node_to_webserver_tunnel_running():
+                await self._start_head_node_to_webserver_tunnel()
+        finally:
+            self._create_node_tasks.remove(asyncio.current_task())
 
     async def _add_node_state_log(self, node_id: NodeId, log_entry: str) -> None:
         async with self._get_node_context(node_id) as node:  # type: Node
@@ -337,3 +347,16 @@ class RayService:
         self._head_node_to_webserver_tunnel_process = None
 
         logger.info("Stopping head node to webserver tunnel done")
+
+    async def _stop_create_node_tasks(self) -> None:
+        task_count = len(self._create_node_tasks)
+        if not task_count:
+            logger.info("Not canceling pending node creation tasks, as no tasks are pending")
+            return
+
+        logger.info("Canceling %d pending node creation tasks...", task_count)
+
+        await ensure_cancelled_many(self._create_node_tasks)
+        self._create_node_tasks.clear()
+
+        logger.info("Canceling %d pending node creation tasks done", task_count)

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -172,6 +172,10 @@ class RayService:
             # TODO: check if node is a head node
             if not self._is_head_node_to_webserver_tunnel_running():
                 await self._start_head_node_to_webserver_tunnel()
+        except RuntimeError as e:
+            async with self._get_node_context(node_id) as node:  # type: Node
+                node.state = NodeState.terminated
+                node.state_log.append(f"Failed to create activity: {e}")
         finally:
             self._create_node_tasks.remove(asyncio.current_task())
 

--- a/ray_on_golem/server/services/utils.py
+++ b/ray_on_golem/server/services/utils.py
@@ -13,6 +13,7 @@ def get_ssh_command(
             "ssh",
             "-o StrictHostKeyChecking=no",
             "-o UserKnownHostsFile=/dev/null",
+            "-o PasswordAuthentication=no",
             f"-o {quote(proxy_command_str)}",
             f"-i {quote(str(ssh_private_key_path))}" if ssh_private_key_path else "",
             quote(ssh_user_str),

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -59,7 +59,7 @@ LOGGING_CONFIG = {
             "propagate": False,
         },
         "ray_on_golem": {
-            "level": "DEBUG",
+            "level": "INFO",
         },
         "golem": {
             "level": "INFO",


### PR DESCRIPTION
What I've done:

* Updated the project to use newest golem-core version from git (until new release)
* Added proposal expiration from buffers, according to new `Proposal.get_expiration_date()` method
* Fixed warnings about legacy fields on `ray up`, by removing them at config building stage
* Fixed problem with hanging SSH subprocesses, by disabling asking for plain password

Notable remarks:
* As built-in providers have built-in support for loading their default values (that's why they don't need to define bunch of empty fields like `file_mounts`, etc), external ones needs to load their defaults by themselves. Its an opportunity to introduce proper minimal yaml requirements.