### PR TITLE
Webserver start / stop command + datadir selection

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Check node creation in logs
         continue-on-error: true
-        run: poetry run python tests/smoke.py /tmp/ray_on_golem/webserver_debug.log
+        run: poetry run python tests/smoke.py ~/.local/share/ray_on_golem/
 
       - name: Collects logs
         if: always()
@@ -48,5 +48,5 @@ jobs:
         with:
           name: logs
           path: |
-            /tmp/ray_on_golem/webserver_debug.log
-            /tmp/ray_on_golem/yagna.log
+            /home/runner/.local/share/ray_on_golem/webserver_debug.log
+            /home/runner/.local/share/ray_on_golem/yagna.log

--- a/ray_on_golem/client/__init__.py
+++ b/ray_on_golem/client/__init__.py
@@ -1,3 +1,3 @@
-from .client import RayOnGolemClient
+from ray_on_golem.client.client import RayOnGolemClient
 
 __all__ = ("RayOnGolemClient",)

--- a/ray_on_golem/client/__init__.py
+++ b/ray_on_golem/client/__init__.py
@@ -1,0 +1,3 @@
+from .client import RayOnGolemClient
+
+__all__ = ("RayOnGolemClient",)

--- a/ray_on_golem/client/client.py
+++ b/ray_on_golem/client/client.py
@@ -171,17 +171,19 @@ class RayOnGolemClient:
 
         return response.shutdown_state
 
-    def is_webserver_serviceable(self) -> Optional[bool]:
+    def get_webserver_status(self) -> Optional[models.WebserverStatus]:
         try:
-            response = self._make_request(
-                url=settings.URL_HEALTH_CHECK,
-                response_model=models.HealthCheckResponseData,
+            return self._make_request(
+                url=settings.URL_STATUS,
+                response_model=models.WebserverStatus,
                 method="GET",
             )
         except RayOnGolemClientError:
             return None
 
-        return response.is_shutting_down
+    def is_webserver_serviceable(self) -> Optional[bool]:
+        status = self.get_webserver_status()
+        return status.shutting_down if status else None
 
     def _make_request(
         self,

--- a/ray_on_golem/client/client.py
+++ b/ray_on_golem/client/client.py
@@ -50,14 +50,21 @@ class RayOnGolemClient:
 
     def terminate_node(self, node_id: models.NodeId) -> Dict[models.NodeId, Dict]:
         logger.info(f"Terminating node %s", node_id)
-        response = self._make_request(
-            url=settings.URL_TERMINATE_NODE,
-            request_data=models.SingleNodeRequestData(
-                node_id=node_id,
-            ),
-            response_model=models.TerminateNodeResponseData,
-            error_message=f"Couldn't terminate node {node_id}",
-        )
+        try:
+            response = self._make_request(
+                url=settings.URL_TERMINATE_NODE,
+                request_data=models.SingleNodeRequestData(
+                    node_id=node_id,
+                ),
+                response_model=models.TerminateNodeResponseData,
+                error_message=f"Couldn't terminate node {node_id}",
+            )
+        except RayOnGolemClientError as e:
+            if e.error_code == 400:
+                logger.error(str(e))
+                return {}
+            else:
+                raise
 
         return response.terminated_nodes
 

--- a/ray_on_golem/client/client.py
+++ b/ray_on_golem/client/client.py
@@ -364,7 +364,7 @@ class RayOnGolemClient:
 
     def is_webserver_serviceable(self) -> Optional[bool]:
         status = self.get_webserver_status()
-        return status.shutting_down if status else None
+        return not status.shutting_down if status else None
 
     def _make_request(
         self,

--- a/ray_on_golem/client/client.py
+++ b/ray_on_golem/client/client.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import requests
 from pydantic import BaseModel, ValidationError
@@ -75,7 +75,7 @@ class RayOnGolemClient:
                     self.wait_for_shutdown()
                 else:
                     cli_logger.print("Not starting webserver, as it's already running")
-                    if datadir and webserver_status.datadir != datadir:
+                    if datadir and webserver_status.datadir != str(datadir):
                         cli_logger.warning(
                             "Specified data directory `{}` is different than webserver's: `{}`. "
                             "Using the webserver setting.",
@@ -326,7 +326,7 @@ class RayOnGolemClient:
 
         return response.ssh_proxy_command
 
-    def get_or_create_default_ssh_key(self, cluster_name: str) -> str:
+    def get_or_create_default_ssh_key(self, cluster_name: str) -> Tuple[str, str]:
         response = self._make_request(
             url=settings.URL_GET_OR_CREATE_DEFAULT_SSH_KEY,
             request_data=models.GetOrCreateDefaultSshKeyRequestData(
@@ -336,7 +336,7 @@ class RayOnGolemClient:
             error_message="Couldn't get or create default ssh key",
         )
 
-        return response.ssh_key_base64
+        return response.ssh_private_key_base64, response.ssh_public_key_base64
 
     def shutdown_webserver(self) -> models.ShutdownState:
         response = self._make_request(

--- a/ray_on_golem/client/client.py
+++ b/ray_on_golem/client/client.py
@@ -1,8 +1,8 @@
+import subprocess
+import time
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
-import subprocess
-import time
 from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 import requests
@@ -22,12 +22,8 @@ from ray_on_golem.server.settings import (
     RAY_ON_GOLEM_SHUTDOWN_DEADLINE,
     RAY_ON_GOLEM_START_DEADLINE,
     get_log_path,
-
 )
-from ray_on_golem.utils import (
-    is_running_on_golem_network,
-    get_last_lines_from_file,
-)
+from ray_on_golem.utils import get_last_lines_from_file, is_running_on_golem_network
 
 TResponseModel = TypeVar("TResponseModel")
 
@@ -359,7 +355,7 @@ class RayOnGolemClient:
                 response_model=models.WebserverStatus,
                 method="GET",
             )
-        except RayOnGolemClientError:
+        except requests.exceptions.ConnectionError:
             return None
 
     def is_webserver_serviceable(self) -> Optional[bool]:
@@ -376,7 +372,8 @@ class RayOnGolemClient:
         method: str = "POST",
     ) -> TResponseModel:
         response = self._session.request(
-            method, str(self._base_url / url.lstrip("/")),
+            method,
+            str(self._base_url / url.lstrip("/")),
             data=request_data.json() if request_data else None,
         )
 

--- a/ray_on_golem/client/client.py
+++ b/ray_on_golem/client/client.py
@@ -1,7 +1,3 @@
-import subprocess
-import time
-from datetime import datetime
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
 
 import requests
@@ -10,19 +6,8 @@ from ray.autoscaler._private.cli_logger import cli_logger  # noqa
 from yarl import URL
 
 from ray_on_golem.client.exceptions import RayOnGolemClientError, RayOnGolemClientValidationError
-from ray_on_golem.log import ZippingRotatingFileHandler
 from ray_on_golem.server import models, settings
-from ray_on_golem.server.models import CreateClusterResponseData, ShutdownState
-from ray_on_golem.server.settings import (
-    LOG_GROUP,
-    LOGGING_BACKUP_COUNT,
-    RAY_ON_GOLEM_CHECK_DEADLINE,
-    RAY_ON_GOLEM_PATH,
-    RAY_ON_GOLEM_SHUTDOWN_DEADLINE,
-    RAY_ON_GOLEM_START_DEADLINE,
-    get_log_path,
-)
-from ray_on_golem.utils import get_last_lines_from_file
+from ray_on_golem.server.models import CreateClusterResponseData
 
 TResponseModel = TypeVar("TResponseModel")
 
@@ -32,138 +17,6 @@ class RayOnGolemClient:
         self.port = port
         self._base_url = URL("http://127.0.0.1").with_port(self.port)
         self._session = requests.Session()
-
-    def start_webserver(
-        self,
-        registry_stats: bool,
-        datadir: Optional[Path] = None,
-        self_shutdown: bool = True,
-    ) -> None:
-        with cli_logger.group(LOG_GROUP):
-            webserver_status = self.get_webserver_status()
-            if webserver_status:
-                if webserver_status.shutting_down:
-                    self.wait_for_shutdown()
-                else:
-                    cli_logger.print("Not starting webserver, as it's already running")
-                    if datadir and webserver_status.datadir != str(datadir):
-                        cli_logger.warning(
-                            "Specified data directory `{}` is different than webserver's: `{}`. "
-                            "Using the webserver setting.",
-                            datadir,
-                            webserver_status.datadir,
-                        )
-                    return
-
-            cli_logger.print(
-                "Starting webserver with deadline up to `{}`...", RAY_ON_GOLEM_START_DEADLINE
-            )
-            args = [
-                RAY_ON_GOLEM_PATH,
-                "webserver",
-                "-p",
-                str(self.port),
-                "--registry-stats" if registry_stats else "--no-registry-stats",
-                "--self-shutdown" if self_shutdown else "--no-self-shutdown",
-            ]
-
-            if datadir:
-                args.extend(["--datadir", datadir])
-
-            cli_logger.verbose("Webserver command: `{}`", " ".join([str(a) for a in args]))
-
-            log_file_path = get_log_path("webserver_debug", datadir)
-            debug_logger = ZippingRotatingFileHandler(
-                log_file_path, backupCount=LOGGING_BACKUP_COUNT
-            )
-            proc = subprocess.Popen(
-                args,
-                stdout=debug_logger.stream,
-                stderr=debug_logger.stream,
-                start_new_session=True,
-            )
-
-            start_deadline = datetime.now() + RAY_ON_GOLEM_START_DEADLINE
-            check_seconds = int(RAY_ON_GOLEM_CHECK_DEADLINE.total_seconds())
-            while datetime.now() < start_deadline:
-                try:
-                    proc.communicate(timeout=check_seconds)
-                except subprocess.TimeoutExpired:
-                    if self.is_webserver_serviceable():
-                        cli_logger.print("Starting webserver done")
-                        return
-                else:
-                    cli_logger.abort(
-                        "Starting webserver failed!\nShowing last 50 lines from `{}`:\n{}",
-                        log_file_path,
-                        get_last_lines_from_file(log_file_path, 50),
-                    )
-
-                cli_logger.print(
-                    "Webserver is not yet running, waiting additional `{}` seconds...",
-                    check_seconds,
-                )
-
-            cli_logger.abort(
-                "Starting webserver failed! Deadline of `{}` reached.\n"
-                "Showing last 50 lines from `{}`:\n{}",
-                RAY_ON_GOLEM_START_DEADLINE,
-                log_file_path,
-                get_last_lines_from_file(log_file_path, 50),
-            )
-
-    def stop_webserver(self) -> None:
-        with cli_logger.group(LOG_GROUP):
-            webserver_serviceable = self.is_webserver_serviceable()
-            if not webserver_serviceable:
-                if webserver_serviceable is None:
-                    cli_logger.print("Not stopping the webserver, as it's not running")
-                else:
-                    cli_logger.print("Not stopping the webserver, as it's already shutting down")
-
-                return
-
-            cli_logger.print("Requesting webserver shutdown...")
-
-            shutdown_state = self.shutdown_webserver()
-
-            if shutdown_state == ShutdownState.NOT_ENABLED:
-                cli_logger.print("Not stopping webserver, as it was started externally")
-                return
-            elif shutdown_state == ShutdownState.CLUSTER_NOT_EMPTY:
-                cli_logger.print("Not stopping webserver, as the cluster is not empty")
-                return
-
-            cli_logger.print("Requesting webserver shutdown done, will stop soon")
-
-    def wait_for_shutdown(self) -> None:
-        cli_logger.print(
-            "Previous webserver instance is still shutting down, "
-            "waiting with deadline up to `{}`...",
-            RAY_ON_GOLEM_SHUTDOWN_DEADLINE,
-        )
-
-        wait_deadline = datetime.now() + RAY_ON_GOLEM_SHUTDOWN_DEADLINE
-        check_seconds = int(RAY_ON_GOLEM_CHECK_DEADLINE.total_seconds())
-
-        time.sleep(check_seconds)
-        while datetime.now() < wait_deadline:
-            webserver_serviceable = self.is_webserver_serviceable()
-            if webserver_serviceable is None:
-                cli_logger.print("Previous webserver instance shutdown done")
-                return
-
-            cli_logger.print(
-                "Previous webserver instance is not yet shutdown, "
-                "waiting additional `{}` seconds...",
-                check_seconds,
-            )
-            time.sleep(check_seconds)
-
-        cli_logger.abort(
-            "Previous webserver instance is still running! Deadline of `{}` reached.",
-            RAY_ON_GOLEM_START_DEADLINE,
-        )
 
     def create_cluster(
         self,

--- a/ray_on_golem/client/client.py
+++ b/ray_on_golem/client/client.py
@@ -49,13 +49,14 @@ class RayOnGolemClient:
         return response.requested_nodes
 
     def terminate_node(self, node_id: models.NodeId) -> Dict[models.NodeId, Dict]:
+        logger.info(f"Terminating node %s", node_id)
         response = self._make_request(
             url=settings.URL_TERMINATE_NODE,
             request_data=models.SingleNodeRequestData(
                 node_id=node_id,
             ),
             response_model=models.TerminateNodeResponseData,
-            error_message="Couldn't terminate node",
+            error_message=f"Couldn't terminate node {node_id}",
         )
 
         return response.terminated_nodes

--- a/ray_on_golem/client/client.py
+++ b/ray_on_golem/client/client.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
 
 import requests
@@ -10,6 +11,8 @@ from ray_on_golem.server import models, settings
 from ray_on_golem.server.models import CreateClusterResponseData
 
 TResponseModel = TypeVar("TResponseModel")
+
+logger = logging.getLogger(__name__)
 
 
 class RayOnGolemClient:
@@ -203,7 +206,8 @@ class RayOnGolemClient:
 
         if response.status_code != 200:
             raise RayOnGolemClientError(
-                f"{error_message or f'Request failed: {url}'}: {response.text}"
+                f"{error_message or f'Request failed: {url}'}: {response.text}",
+                error_code=response.status_code,
             )
 
         try:

--- a/ray_on_golem/client/exceptions.py
+++ b/ray_on_golem/client/exceptions.py
@@ -2,8 +2,7 @@ from ray_on_golem.exceptions import RayOnGolemError
 
 
 class RayOnGolemClientError(RayOnGolemError):
-
-    def __init__(self, msg = "", error_code = None):
+    def __init__(self, msg="", error_code=None):
         super().__init__(msg)
         self.error_code = error_code
 

--- a/ray_on_golem/client/exceptions.py
+++ b/ray_on_golem/client/exceptions.py
@@ -2,7 +2,14 @@ from ray_on_golem.exceptions import RayOnGolemError
 
 
 class RayOnGolemClientError(RayOnGolemError):
-    pass
+
+    def __init__(self, msg = "", error_code = None):
+        super().__init__(msg)
+        self.error_code = error_code
+
+    def __str__(self):
+        error_code = f"{self.error_code}: " if self.error_code else ""
+        return f"{error_code}{super().__str__()}"
 
 
 class RayOnGolemClientValidationError(RayOnGolemClientError):

--- a/ray_on_golem/ctl/__init__.py
+++ b/ray_on_golem/ctl/__init__.py
@@ -1,0 +1,3 @@
+from ray_on_golem.ctl.ctl import RayOnGolemCtl
+
+__all__ = "RayOnGolemCtl"

--- a/ray_on_golem/ctl/ctl.py
+++ b/ray_on_golem/ctl/ctl.py
@@ -104,7 +104,9 @@ class RayOnGolemCtl:
             if webserver_serviceable is None:
                 self._output_logger.info("Not stopping the webserver, as it's not running")
             else:
-                self._output_logger.info("Not stopping the webserver, as it's already shutting down")
+                self._output_logger.info(
+                    "Not stopping the webserver, as it's already shutting down"
+                )
 
             return
 

--- a/ray_on_golem/ctl/ctl.py
+++ b/ray_on_golem/ctl/ctl.py
@@ -1,0 +1,149 @@
+import subprocess
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from ray_on_golem.log import ZippingRotatingFileHandler
+from ray_on_golem.server.models import ShutdownState
+from ray_on_golem.server.settings import (
+    LOGGING_BACKUP_COUNT,
+    RAY_ON_GOLEM_CHECK_DEADLINE,
+    RAY_ON_GOLEM_PATH,
+    RAY_ON_GOLEM_SHUTDOWN_DEADLINE,
+    RAY_ON_GOLEM_START_DEADLINE,
+    get_log_path,
+)
+from ray_on_golem.utils import get_last_lines_from_file
+
+if TYPE_CHECKING:
+    from ray_on_golem.client import RayOnGolemClient
+    from ray_on_golem.ctl.log import RayOnGolemCtlLogger
+
+
+class RayOnGolemCtl:
+    def __init__(self, client: "RayOnGolemClient", output_logger: "RayOnGolemCtlLogger"):
+        self.client = client
+        self.output_logger = output_logger
+
+    def start_webserver(
+        self,
+        registry_stats: bool,
+        datadir: Optional[Path] = None,
+        self_shutdown: bool = True,
+    ) -> None:
+        webserver_status = self.client.get_webserver_status()
+        if webserver_status:
+            if webserver_status.shutting_down:
+                self.wait_for_shutdown()
+            else:
+                self.output_logger.info("Not starting webserver, as it's already running")
+                if datadir and webserver_status.datadir != str(datadir):
+                    self.output_logger.warning(
+                        f"Specified data directory `{datadir}` "
+                        f"is different than webserver's: `{webserver_status.datadir}`. "
+                        "Using the webserver setting."
+                    )
+                return
+
+        self.output_logger.info(
+            f"Starting webserver with deadline up to `{RAY_ON_GOLEM_START_DEADLINE}`..."
+        )
+        args = [
+            RAY_ON_GOLEM_PATH,
+            "webserver",
+            "-p",
+            str(self.client.port),
+            "--registry-stats" if registry_stats else "--no-registry-stats",
+            "--self-shutdown" if self_shutdown else "--no-self-shutdown",
+        ]
+
+        if datadir:
+            args.extend(["--datadir", datadir])
+
+        self.output_logger.verbose(f"Webserver command: `{' '.join([str(a) for a in args])}`")
+
+        log_file_path = get_log_path("webserver_debug", datadir)
+        debug_logger = ZippingRotatingFileHandler(log_file_path, backupCount=LOGGING_BACKUP_COUNT)
+        proc = subprocess.Popen(
+            args,
+            stdout=debug_logger.stream,
+            stderr=debug_logger.stream,
+            start_new_session=True,
+        )
+
+        start_deadline = datetime.now() + RAY_ON_GOLEM_START_DEADLINE
+        check_seconds = int(RAY_ON_GOLEM_CHECK_DEADLINE.total_seconds())
+        while datetime.now() < start_deadline:
+            try:
+                proc.communicate(timeout=check_seconds)
+            except subprocess.TimeoutExpired:
+                if self.client.is_webserver_serviceable():
+                    self.output_logger.info("Starting webserver done")
+                    return
+            else:
+                self.output_logger.error(
+                    "Starting webserver failed!\n"
+                    f"Showing last 50 lines from `{log_file_path}`:\n"
+                    f"{get_last_lines_from_file(log_file_path, 50)}"
+                )
+
+            self.output_logger.info(
+                f"Webserver is not yet running, waiting additional `{check_seconds}` seconds..."
+            )
+
+        self.output_logger.error(
+            f"Starting webserver failed! Deadline of `{RAY_ON_GOLEM_START_DEADLINE}` reached.\n"
+            "Showing last 50 lines from "
+            f"`{log_file_path}`:\n{get_last_lines_from_file(log_file_path, 50)}"
+        )
+
+    def stop_webserver(self) -> None:
+        webserver_serviceable = self.client.is_webserver_serviceable()
+        if not webserver_serviceable:
+            if webserver_serviceable is None:
+                self.output_logger.info("Not stopping the webserver, as it's not running")
+            else:
+                self.output_logger.info("Not stopping the webserver, as it's already shutting down")
+
+            return
+
+        self.output_logger.info("Requesting webserver shutdown...")
+
+        shutdown_state = self.client.shutdown_webserver()
+
+        if shutdown_state == ShutdownState.NOT_ENABLED:
+            self.output_logger.info("Not stopping webserver, as it was started externally")
+            return
+        elif shutdown_state == ShutdownState.CLUSTER_NOT_EMPTY:
+            self.output_logger.info("Not stopping webserver, as the cluster is not empty")
+            return
+
+        self.output_logger.info("Requesting webserver shutdown done, will stop soon")
+
+    def wait_for_shutdown(self) -> None:
+        self.output_logger.info(
+            "Previous webserver instance is still shutting down, "
+            f"waiting with deadline up to `{RAY_ON_GOLEM_SHUTDOWN_DEADLINE}`...",
+        )
+
+        wait_deadline = datetime.now() + RAY_ON_GOLEM_SHUTDOWN_DEADLINE
+        check_seconds = int(RAY_ON_GOLEM_CHECK_DEADLINE.total_seconds())
+
+        time.sleep(check_seconds)
+        while datetime.now() < wait_deadline:
+            webserver_serviceable = self.client.is_webserver_serviceable()
+            if webserver_serviceable is None:
+                self.output_logger.info("Previous webserver instance shutdown done")
+                return
+
+            self.output_logger.info(
+                "Previous webserver instance is not yet shutdown, "
+                f"waiting additional `{check_seconds}` seconds..."
+            )
+            time.sleep(check_seconds)
+
+        self.output_logger.error(
+            "Previous webserver instance is still running! "
+            f"Deadline of `{RAY_ON_GOLEM_START_DEADLINE}` reached."
+        )

--- a/ray_on_golem/ctl/ctl.py
+++ b/ray_on_golem/ctl/ctl.py
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
 
 class RayOnGolemCtl:
     def __init__(self, client: "RayOnGolemClient", output_logger: "RayOnGolemCtlLogger"):
-        self.client = client
-        self.output_logger = output_logger
+        self._client = client
+        self._output_logger = output_logger
 
     def start_webserver(
         self,
@@ -32,28 +32,28 @@ class RayOnGolemCtl:
         datadir: Optional[Path] = None,
         self_shutdown: bool = True,
     ) -> None:
-        webserver_status = self.client.get_webserver_status()
+        webserver_status = self._client.get_webserver_status()
         if webserver_status:
             if webserver_status.shutting_down:
                 self.wait_for_shutdown()
             else:
-                self.output_logger.info("Not starting webserver, as it's already running")
+                self._output_logger.info("Not starting webserver, as it's already running")
                 if datadir and webserver_status.datadir != str(datadir):
-                    self.output_logger.warning(
+                    self._output_logger.warning(
                         f"Specified data directory `{datadir}` "
                         f"is different than webserver's: `{webserver_status.datadir}`. "
                         "Using the webserver setting."
                     )
                 return
 
-        self.output_logger.info(
+        self._output_logger.info(
             f"Starting webserver with deadline up to `{RAY_ON_GOLEM_START_DEADLINE}`..."
         )
         args = [
             RAY_ON_GOLEM_PATH,
             "webserver",
             "-p",
-            str(self.client.port),
+            str(self._client.port),
             "--registry-stats" if registry_stats else "--no-registry-stats",
             "--self-shutdown" if self_shutdown else "--no-self-shutdown",
         ]
@@ -61,7 +61,7 @@ class RayOnGolemCtl:
         if datadir:
             args.extend(["--datadir", datadir])
 
-        self.output_logger.verbose(f"Webserver command: `{' '.join([str(a) for a in args])}`")
+        self._output_logger.verbose(f"Webserver command: `{' '.join([str(a) for a in args])}`")
 
         log_file_path = get_log_path("webserver_debug", datadir)
         debug_logger = ZippingRotatingFileHandler(log_file_path, backupCount=LOGGING_BACKUP_COUNT)
@@ -78,51 +78,51 @@ class RayOnGolemCtl:
             try:
                 proc.communicate(timeout=check_seconds)
             except subprocess.TimeoutExpired:
-                if self.client.is_webserver_serviceable():
-                    self.output_logger.info("Starting webserver done")
+                if self._client.is_webserver_serviceable():
+                    self._output_logger.info("Starting webserver done")
                     return
             else:
-                self.output_logger.error(
+                self._output_logger.error(
                     "Starting webserver failed!\n"
                     f"Showing last 50 lines from `{log_file_path}`:\n"
                     f"{get_last_lines_from_file(log_file_path, 50)}"
                 )
 
-            self.output_logger.info(
+            self._output_logger.info(
                 f"Webserver is not yet running, waiting additional `{check_seconds}` seconds..."
             )
 
-        self.output_logger.error(
+        self._output_logger.error(
             f"Starting webserver failed! Deadline of `{RAY_ON_GOLEM_START_DEADLINE}` reached.\n"
             "Showing last 50 lines from "
             f"`{log_file_path}`:\n{get_last_lines_from_file(log_file_path, 50)}"
         )
 
     def stop_webserver(self) -> None:
-        webserver_serviceable = self.client.is_webserver_serviceable()
+        webserver_serviceable = self._client.is_webserver_serviceable()
         if not webserver_serviceable:
             if webserver_serviceable is None:
-                self.output_logger.info("Not stopping the webserver, as it's not running")
+                self._output_logger.info("Not stopping the webserver, as it's not running")
             else:
-                self.output_logger.info("Not stopping the webserver, as it's already shutting down")
+                self._output_logger.info("Not stopping the webserver, as it's already shutting down")
 
             return
 
-        self.output_logger.info("Requesting webserver shutdown...")
+        self._output_logger.info("Requesting webserver shutdown...")
 
-        shutdown_state = self.client.shutdown_webserver()
+        shutdown_state = self._client.shutdown_webserver()
 
         if shutdown_state == ShutdownState.NOT_ENABLED:
-            self.output_logger.info("Not stopping webserver, as it was started externally")
+            self._output_logger.info("Not stopping webserver, as it was started externally")
             return
         elif shutdown_state == ShutdownState.CLUSTER_NOT_EMPTY:
-            self.output_logger.info("Not stopping webserver, as the cluster is not empty")
+            self._output_logger.info("Not stopping webserver, as the cluster is not empty")
             return
 
-        self.output_logger.info("Requesting webserver shutdown done, will stop soon")
+        self._output_logger.info("Requesting webserver shutdown done, will stop soon")
 
     def wait_for_shutdown(self) -> None:
-        self.output_logger.info(
+        self._output_logger.info(
             "Previous webserver instance is still shutting down, "
             f"waiting with deadline up to `{RAY_ON_GOLEM_SHUTDOWN_DEADLINE}`...",
         )
@@ -132,18 +132,18 @@ class RayOnGolemCtl:
 
         time.sleep(check_seconds)
         while datetime.now() < wait_deadline:
-            webserver_serviceable = self.client.is_webserver_serviceable()
+            webserver_serviceable = self._client.is_webserver_serviceable()
             if webserver_serviceable is None:
-                self.output_logger.info("Previous webserver instance shutdown done")
+                self._output_logger.info("Previous webserver instance shutdown done")
                 return
 
-            self.output_logger.info(
+            self._output_logger.info(
                 "Previous webserver instance is not yet shutdown, "
                 f"waiting additional `{check_seconds}` seconds..."
             )
             time.sleep(check_seconds)
 
-        self.output_logger.error(
+        self._output_logger.error(
             "Previous webserver instance is still running! "
             f"Deadline of `{RAY_ON_GOLEM_START_DEADLINE}` reached."
         )

--- a/ray_on_golem/ctl/log.py
+++ b/ray_on_golem/ctl/log.py
@@ -1,0 +1,43 @@
+from abc import ABC, abstractmethod
+
+import colorful
+
+
+class RayOnGolemCtlError(Exception):
+    ...
+
+
+class RayOnGolemCtlLogger(ABC):
+    @abstractmethod
+    def info(self, msg: str):
+        """Handle a regular info-level message."""
+
+    @abstractmethod
+    def warning(self, msg: str):
+        """Handle a warning-level message."""
+
+    @abstractmethod
+    def verbose(self, msg: str):
+        """Handle a verbose-level message."""
+
+    @abstractmethod
+    def error(self, msg: str):
+        """Handle an error"""
+
+
+class RayOnGolemCtlConsoleLogger(RayOnGolemCtlLogger):
+    def __init__(self, verbose=False):
+        self._output_verbose = verbose
+
+    def info(self, msg: str):
+        print(msg)
+
+    def warning(self, msg: str):
+        print(colorful.yellow(msg))
+
+    def verbose(self, msg: str):
+        if self._output_verbose:
+            print(msg)
+
+    def error(self, msg: str):
+        raise RayOnGolemCtlError(msg)

--- a/ray_on_golem/main.py
+++ b/ray_on_golem/main.py
@@ -2,7 +2,6 @@ import click
 
 from ray_on_golem.network_stats import main as network_stats
 from ray_on_golem.server import main as webserver
-from ray_on_golem.utils import prepare_tmp_dir
 from ray_on_golem.version import version
 
 
@@ -16,9 +15,8 @@ cli.add_command(version)
 cli.add_command(webserver)
 
 
-def main():
-    prepare_tmp_dir()
 
+def main():
     cli()
 
 

--- a/ray_on_golem/main.py
+++ b/ray_on_golem/main.py
@@ -1,7 +1,8 @@
 import click
 
 from ray_on_golem.network_stats import main as network_stats
-from ray_on_golem.server import main as webserver, start, stop
+from ray_on_golem.server import main as webserver
+from ray_on_golem.server import start, stop
 from ray_on_golem.version import version
 
 

--- a/ray_on_golem/main.py
+++ b/ray_on_golem/main.py
@@ -1,7 +1,7 @@
 import click
 
 from ray_on_golem.network_stats import main as network_stats
-from ray_on_golem.server import main as webserver
+from ray_on_golem.server import main as webserver, start, stop
 from ray_on_golem.version import version
 
 
@@ -13,7 +13,8 @@ def cli():
 cli.add_command(network_stats)
 cli.add_command(version)
 cli.add_command(webserver)
-
+cli.add_command(start)
+cli.add_command(stop)
 
 
 def main():

--- a/ray_on_golem/network_stats/main.py
+++ b/ray_on_golem/network_stats/main.py
@@ -11,7 +11,7 @@ import yaml
 from ray_on_golem.network_stats.services import NetworkStatsService
 from ray_on_golem.provider.node_provider import GolemNodeProvider
 from ray_on_golem.server.services import YagnaService
-from ray_on_golem.server.settings import get_logging_config, DEFAULT_DATADIR, YAGNA_PATH
+from ray_on_golem.server.settings import DEFAULT_DATADIR, YAGNA_PATH, get_logging_config
 
 
 @click.command(
@@ -38,7 +38,7 @@ from ray_on_golem.server.settings import get_logging_config, DEFAULT_DATADIR, YA
     "--datadir",
     type=pathlib.Path,
     help=f"Ray on Golem's data directory. [default: {DEFAULT_DATADIR}"
-         " (unless `webserver_datadir` is defined in the cluster config file)]",
+    " (unless `webserver_datadir` is defined in the cluster config file)]",
 )
 def main(
     cluster_config_file: str,
@@ -72,7 +72,10 @@ async def _network_stats(provider_params: Dict, duration: int, datadir: Optional
 
 @asynccontextmanager
 async def network_stats_service(
-    registry_stats: bool, network: str, driver: str, datadir: Optional[pathlib.Path],
+    registry_stats: bool,
+    network: str,
+    driver: str,
+    datadir: Optional[pathlib.Path],
 ) -> NetworkStatsService:
     network_stats_service: NetworkStatsService = NetworkStatsService(registry_stats)
     yagna_service = YagnaService(

--- a/ray_on_golem/network_stats/main.py
+++ b/ray_on_golem/network_stats/main.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
 import logging.config
+import pathlib
 from contextlib import asynccontextmanager
-from typing import Dict
+from typing import Dict, Optional
 
 import click
 import yaml
@@ -10,8 +11,7 @@ import yaml
 from ray_on_golem.network_stats.services import NetworkStatsService
 from ray_on_golem.provider.node_provider import GolemNodeProvider
 from ray_on_golem.server.services import YagnaService
-from ray_on_golem.server.settings import LOGGING_CONFIG, YAGNA_PATH
-from ray_on_golem.utils import prepare_tmp_dir
+from ray_on_golem.server.settings import get_logging_config, DEFAULT_DATADIR, YAGNA_PATH
 
 
 @click.command(
@@ -34,36 +34,50 @@ from ray_on_golem.utils import prepare_tmp_dir
     default=False,
     help="Enable verbose logging.",
 )
-def main(cluster_config_file: str, duration: int, enable_logging: bool):
-    if enable_logging:
-        logging.config.dictConfig(LOGGING_CONFIG)
-
+@click.option(
+    "--datadir",
+    type=pathlib.Path,
+    help=f"Ray on Golem's data directory. [default: {DEFAULT_DATADIR}"
+         " (unless `webserver_datadir` is defined in the cluster config file)]",
+)
+def main(
+    cluster_config_file: str,
+    duration: int,
+    enable_logging: bool,
+    datadir: Optional[pathlib.Path],
+):
     with open(cluster_config_file) as file:
         config = yaml.safe_load(file.read())
 
     GolemNodeProvider._apply_config_defaults(config)
-
-    asyncio.run(_network_stats(config, duration))
-
-
-async def _network_stats(config: Dict, duration: int):
     provider_params = config["provider"]["parameters"]
 
+    datadir = datadir or provider_params["webserver_datadir"]
+
+    if enable_logging:
+        logging.config.dictConfig(get_logging_config(datadir=datadir))
+
+    asyncio.run(_network_stats(provider_params, duration, datadir))
+
+
+async def _network_stats(provider_params: Dict, duration: int, datadir: Optional[pathlib.Path]):
     async with network_stats_service(
         provider_params["enable_registry_stats"],
         provider_params["payment_network"],
         provider_params["payment_driver"],
+        datadir,
     ) as stats_service:
         await stats_service.run(provider_params, duration)
 
 
 @asynccontextmanager
 async def network_stats_service(
-    registry_stats: bool, network: str, driver: str
+    registry_stats: bool, network: str, driver: str, datadir: Optional[pathlib.Path],
 ) -> NetworkStatsService:
     network_stats_service: NetworkStatsService = NetworkStatsService(registry_stats)
     yagna_service = YagnaService(
         yagna_path=YAGNA_PATH,
+        datadir=datadir,
     )
 
     await yagna_service.init()
@@ -78,5 +92,4 @@ async def network_stats_service(
 
 
 if __name__ == "__main__":
-    prepare_tmp_dir()
     main()

--- a/ray_on_golem/provider/log.py
+++ b/ray_on_golem/provider/log.py
@@ -1,0 +1,17 @@
+from ray.autoscaler._private.cli_logger import cli_logger  # noqa
+
+from ray_on_golem.ctl.log import RayOnGolemCtlLogger
+
+
+class NodeProviderCliLogger(RayOnGolemCtlLogger):
+    def info(self, msg: str):
+        cli_logger.print(msg)
+
+    def warning(self, msg: str):
+        cli_logger.warning(msg)
+
+    def verbose(self, msg: str):
+        cli_logger.verbose(msg)
+
+    def error(self, msg: str):
+        cli_logger.abort(msg)

--- a/ray_on_golem/provider/node_provider.py
+++ b/ray_on_golem/provider/node_provider.py
@@ -1,47 +1,36 @@
-import logging
-import pathlib
-import subprocess
 import time
 from copy import deepcopy
 from datetime import datetime
-from functools import lru_cache
 from types import ModuleType
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional
 
-from ray.autoscaler._private.cli_logger import cli_logger
-from ray.autoscaler._private.event_system import CreateClusterEvent, global_event_system
+from ray.autoscaler._private.cli_logger import cli_logger  # noqa
+from ray.autoscaler._private.event_system import CreateClusterEvent, global_event_system  # noqa
 from ray.autoscaler.command_runner import CommandRunnerInterface
 from ray.autoscaler.node_provider import NodeProvider
 
-from ray_on_golem.client.client import RayOnGolemClient
-from ray_on_golem.log import ZippingRotatingFileHandler
 from ray_on_golem.provider.ssh_command_runner import SSHCommandRunner
-from ray_on_golem.server.models import NodeData, NodeId, NodeState, ShutdownState
+from ray_on_golem.client import RayOnGolemClient
+from ray_on_golem.server.models import NodeData, NodeId, NodeState
 from ray_on_golem.server.settings import (
-    LOGGING_BACKUP_COUNT,
+    LOG_GROUP,
     PAYMENT_DRIVER_ERC20,
     PAYMENT_NETWORK_GOERLI,
     PAYMENT_NETWORK_MAINNET,
     PAYMENT_NETWORK_POLYGON,
     TMP_PATH,
-    RAY_ON_GOLEM_CHECK_DEADLINE,
-    RAY_ON_GOLEM_PATH,
-    RAY_ON_GOLEM_SHUTDOWN_DEADLINE,
-    RAY_ON_GOLEM_START_DEADLINE,
-    get_log_path,
 )
 from ray_on_golem.utils import (
     get_default_ssh_key_name,
-    get_last_lines_from_file,
     is_running_on_golem_network,
 )
-from ray_on_golem.version import get_version
-
-LOG_GROUP = f"Ray On Golem {get_version()}"
 
 ONBOARDING_MESSAGE = {
-    PAYMENT_NETWORK_MAINNET: "Running Ray on Golem on the Ethereum Mainnet requires GLM and ETH tokens.",
-    PAYMENT_NETWORK_POLYGON: "Running Ray on Golem on the mainnet requires GLM and MATIC tokens on the Polygon blockchain (see: https://docs.golem.network/docs/creators/ray/mainnet).",
+    PAYMENT_NETWORK_MAINNET:
+        "Running Ray on Golem on the Ethereum Mainnet requires GLM and ETH tokens.",
+    PAYMENT_NETWORK_POLYGON:
+        "Running Ray on Golem on the mainnet requires GLM and MATIC tokens "
+        "on the Polygon blockchain (see: https://docs.golem.network/docs/creators/ray/mainnet).",
 }
 
 PROVIDER_DEFAULTS = {
@@ -57,13 +46,11 @@ PROVIDER_DEFAULTS = {
 
 class GolemNodeProvider(NodeProvider):
     def __init__(self, provider_config: Dict[str, Any], cluster_name: str):
-        print("----------------------------------------------- GOLEM NODE PROVIDER INIT")
-        cli_logger.print("---------------------------------------------- GOLEM NODE PROVIDER INIT")
         super().__init__(provider_config, cluster_name)
 
         provider_parameters: Dict = provider_config["parameters"]
 
-        self._ray_on_golem_client = self._get_ray_on_golem_client_instance(
+        self._ray_on_golem_client = RayOnGolemClient.get_instance(
             webserver_port=provider_parameters["webserver_port"],
             enable_registry_stats=provider_parameters["enable_registry_stats"],
             datadir=provider_parameters["webserver_datadir"],
@@ -87,14 +74,12 @@ class GolemNodeProvider(NodeProvider):
 
     @classmethod
     def bootstrap_config(cls, cluster_config: Dict[str, Any]) -> Dict[str, Any]:
-        print("--------------------------------------------- GOLEM NODE BOOTSTRAP CONFIG")
-        cli_logger.print("-------------------------------------------- GOLEM NODE BOOTSTRAP CONFIG")
         config = deepcopy(cluster_config)
 
         cls._apply_config_defaults(config)
 
         provider_parameters = config["provider"]["parameters"]
-        ray_on_golem_client = cls._get_ray_on_golem_client_instance(
+        ray_on_golem_client = RayOnGolemClient.get_instance(
             webserver_port=provider_parameters["webserver_port"],
             enable_registry_stats=provider_parameters["enable_registry_stats"],
             datadir=provider_parameters["webserver_datadir"],
@@ -119,32 +104,6 @@ class GolemNodeProvider(NodeProvider):
         )
 
         return config
-
-    @classmethod
-    @lru_cache()
-    def _get_ray_on_golem_client_instance(
-        cls,
-        webserver_port: int,
-        enable_registry_stats: bool,
-        datadir: Optional[Union[str, pathlib.Path]] = None,
-        self_shutdown: bool = True,
-    ):
-        ray_on_golem_client = RayOnGolemClient(webserver_port)
-
-        if datadir and not isinstance(datadir, pathlib.Path):
-            datadir = pathlib.Path(datadir)
-
-        if not is_running_on_golem_network():
-            # iow, the code is executed on a requestor agent and not inside the VM on a provider
-            cls._start_webserver(
-                ray_on_golem_client,
-                webserver_port,
-                enable_registry_stats,
-                datadir,
-                self_shutdown,
-            )
-
-        return ray_on_golem_client
 
     def get_command_runner(
         self,
@@ -282,143 +241,6 @@ class GolemNodeProvider(NodeProvider):
         # copy ssh details to provider namespace for cluster creation in __init__
         provider_parameters["_ssh_private_key"] = auth["ssh_private_key"]
         provider_parameters["_ssh_user"] = auth["ssh_user"]
-
-    @classmethod
-    def _start_webserver(
-        cls,
-        ray_on_golem_client: RayOnGolemClient,
-        port: int,
-        registry_stats: bool,
-        datadir: Optional[pathlib.Path] = None,
-        self_shutdown: bool = True,
-    ) -> None:
-        with cli_logger.group(LOG_GROUP):
-            webserver_status = ray_on_golem_client.get_webserver_status()
-            if webserver_status:
-                if webserver_status.shutting_down:
-                    cls._wait_for_shutdown(ray_on_golem_client)
-                else:
-                    cli_logger.print("Not starting webserver, as it's already running")
-                    if datadir and webserver_status.datadir != datadir:
-                        cli_logger.warning(
-                            "Specified data directory `{}` is different than webserver's: `{}`. "
-                            "Using the webserver setting.",
-                            datadir,
-                            webserver_status.datadir,
-                        )
-
-                    # if webserver_status.datadir != datadir:
-                    #     cli_logger.warning("Started webserver")
-                    return
-
-            cli_logger.print(
-                "Starting webserver with deadline up to `{}`...", RAY_ON_GOLEM_START_DEADLINE
-            )
-            args = [
-                RAY_ON_GOLEM_PATH,
-                "webserver",
-                "-p",
-                str(port),
-                "--registry-stats" if registry_stats else "--no-registry-stats",
-                "--self-shutdown" if self_shutdown else "--no-self-shutdown",
-            ]
-
-            if datadir:
-                args.extend(["--datadir", datadir])
-
-            cli_logger.verbose("Webserver command: `{}`", " ".join([str(a) for a in args]))
-
-            log_file_path = get_log_path("webserver_debug", datadir)
-            debug_logger = ZippingRotatingFileHandler(
-                log_file_path, backupCount=LOGGING_BACKUP_COUNT
-            )
-            proc = subprocess.Popen(
-                args,
-                stdout=debug_logger.stream,
-                stderr=debug_logger.stream,
-                start_new_session=True,
-            )
-
-            start_deadline = datetime.now() + RAY_ON_GOLEM_START_DEADLINE
-            check_seconds = int(RAY_ON_GOLEM_CHECK_DEADLINE.total_seconds())
-            while datetime.now() < start_deadline:
-                try:
-                    proc.communicate(timeout=check_seconds)
-                except subprocess.TimeoutExpired:
-                    if ray_on_golem_client.is_webserver_serviceable():
-                        cli_logger.print("Starting webserver done")
-                        return
-                else:
-                    cli_logger.abort(
-                        "Starting webserver failed!\nShowing last 50 lines from `{}`:\n{}",
-                        log_file_path,
-                        get_last_lines_from_file(log_file_path, 50),
-                    )
-
-                cli_logger.print(
-                    "Webserver is not yet running, waiting additional `{}` seconds...",
-                    check_seconds,
-                )
-
-            cli_logger.abort(
-                "Starting webserver failed! Deadline of `{}` reached.\nShowing last 50 lines from `{}`:\n{}",
-                RAY_ON_GOLEM_START_DEADLINE,
-                log_file_path,
-                get_last_lines_from_file(log_file_path, 50),
-            )
-
-    @staticmethod
-    def _stop_webserver(ray_on_golem_client: RayOnGolemClient) -> None:
-        with cli_logger.group(LOG_GROUP):
-            webserver_serviceable = ray_on_golem_client.is_webserver_serviceable()
-            if not webserver_serviceable:
-                if webserver_serviceable is None:
-                    cli_logger.print("Not stopping the webserver, as it's not running")
-                else:
-                    cli_logger.print("Not stopping the webserver, as it's already shutting down")
-
-                return
-
-            cli_logger.print("Requesting webserver shutdown...")
-
-            shutdown_state = ray_on_golem_client.shutdown_webserver()
-
-            if shutdown_state == ShutdownState.NOT_ENABLED:
-                cli_logger.print("Not stopping webserver, as it was started externally")
-                return
-            elif shutdown_state == ShutdownState.CLUSTER_NOT_EMPTY:
-                cli_logger.print("Not stopping webserver, as the cluster is not empty")
-                return
-
-            cli_logger.print("Requesting webserver shutdown done, will stop soon")
-
-    @staticmethod
-    def _wait_for_shutdown(ray_on_golem_client: RayOnGolemClient) -> None:
-        cli_logger.print(
-            "Previous webserver instance is still shutting down, waiting with deadline up to `{}`...",
-            RAY_ON_GOLEM_SHUTDOWN_DEADLINE,
-        )
-
-        wait_deadline = datetime.now() + RAY_ON_GOLEM_SHUTDOWN_DEADLINE
-        check_seconds = int(RAY_ON_GOLEM_CHECK_DEADLINE.total_seconds())
-
-        time.sleep(check_seconds)
-        while datetime.now() < wait_deadline:
-            webserver_serviceable = ray_on_golem_client.is_webserver_serviceable()
-            if webserver_serviceable is None:
-                cli_logger.print("Previous webserver instance shutdown done")
-                return
-
-            cli_logger.print(
-                "Previous webserver instance is not yet shutdown, waiting additional `{}` seconds...",
-                check_seconds,
-            )
-            time.sleep(check_seconds)
-
-        cli_logger.abort(
-            "Previous webserver instance is still running! Deadline of `{}` reached.",
-            RAY_ON_GOLEM_START_DEADLINE,
-        )
 
     def _print_mainnet_onboarding_message(self, yagna_payment_status_output: str) -> None:
         if self._payment_network not in ONBOARDING_MESSAGE:

--- a/ray_on_golem/provider/node_provider.py
+++ b/ray_on_golem/provider/node_provider.py
@@ -9,8 +9,8 @@ from ray.autoscaler._private.event_system import CreateClusterEvent, global_even
 from ray.autoscaler.command_runner import CommandRunnerInterface
 from ray.autoscaler.node_provider import NodeProvider
 
-from ray_on_golem.provider.ssh_command_runner import SSHCommandRunner
 from ray_on_golem.client import RayOnGolemClient
+from ray_on_golem.provider.ssh_command_runner import SSHCommandRunner
 from ray_on_golem.server.models import NodeData, NodeId, NodeState
 from ray_on_golem.server.settings import (
     LOG_GROUP,
@@ -20,17 +20,12 @@ from ray_on_golem.server.settings import (
     PAYMENT_NETWORK_POLYGON,
     TMP_PATH,
 )
-from ray_on_golem.utils import (
-    get_default_ssh_key_name,
-    is_running_on_golem_network,
-)
+from ray_on_golem.utils import get_default_ssh_key_name, is_running_on_golem_network
 
 ONBOARDING_MESSAGE = {
-    PAYMENT_NETWORK_MAINNET:
-        "Running Ray on Golem on the Ethereum Mainnet requires GLM and ETH tokens.",
-    PAYMENT_NETWORK_POLYGON:
-        "Running Ray on Golem on the mainnet requires GLM and MATIC tokens "
-        "on the Polygon blockchain (see: https://docs.golem.network/docs/creators/ray/mainnet).",
+    PAYMENT_NETWORK_MAINNET: "Running Ray on Golem on the Ethereum Mainnet requires GLM and ETH tokens.",
+    PAYMENT_NETWORK_POLYGON: "Running Ray on Golem on the mainnet requires GLM and MATIC tokens "
+    "on the Polygon blockchain (see: https://docs.golem.network/docs/creators/ray/mainnet).",
 }
 
 PROVIDER_DEFAULTS = {
@@ -194,7 +189,7 @@ class GolemNodeProvider(NodeProvider):
     def terminate_node(self, node_id: NodeId) -> Dict[NodeId, Dict]:
         terminated_nodes = self._ray_on_golem_client.terminate_node(node_id)
 
-        self._stop_webserver(self._ray_on_golem_client)
+        self._ray_on_golem_client.stop_webserver()
 
         return terminated_nodes
 

--- a/ray_on_golem/provider/node_provider.py
+++ b/ray_on_golem/provider/node_provider.py
@@ -1,3 +1,4 @@
+import os
 import time
 from copy import deepcopy
 from datetime import datetime
@@ -85,13 +86,19 @@ class GolemNodeProvider(NodeProvider):
         default_ssh_private_key = TMP_PATH / get_default_ssh_key_name(config["cluster_name"])
         if auth["ssh_private_key"] == str(default_ssh_private_key):
             if not default_ssh_private_key.exists():
-                ssh_key_base64 = ray_on_golem_client.get_or_create_default_ssh_key(
+                priv_base64, pub_base64 = ray_on_golem_client.get_or_create_default_ssh_key(
                     config["cluster_name"]
                 )
 
                 default_ssh_private_key.parent.mkdir(parents=True, exist_ok=True)
+                pub_key_path = default_ssh_private_key.with_suffix(".pub")
                 with default_ssh_private_key.open("w") as f:
-                    f.write(ssh_key_base64)
+                    f.write(priv_base64)
+
+                os.chmod(default_ssh_private_key, 0o600)
+
+                with pub_key_path.open("w") as f:
+                    f.write(pub_base64)
 
         global_event_system.execute_callback(
             CreateClusterEvent.ssh_keypair_downloaded,

--- a/ray_on_golem/server/__init__.py
+++ b/ray_on_golem/server/__init__.py
@@ -1,3 +1,3 @@
-from ray_on_golem.server.main import main
+from ray_on_golem.server.main import main, start, stop
 
-__all__ = ("main",)
+__all__ = ("main", "start", "stop")

--- a/ray_on_golem/server/main.py
+++ b/ray_on_golem/server/main.py
@@ -174,9 +174,11 @@ async def ray_service_ctx(app: web.Application) -> None:
 )
 def start(port: int, registry_stats: bool, datadir: Optional[Path] = None):
     from ray_on_golem.client import RayOnGolemClient
+    from ray_on_golem.ctl import RayOnGolemCtl
+    from ray_on_golem.ctl.log import RayOnGolemCtlConsoleLogger
 
-    client = RayOnGolemClient(port)
-    client.start_webserver(
+    ctl = RayOnGolemCtl(RayOnGolemClient(port), RayOnGolemCtlConsoleLogger())
+    ctl.start_webserver(
         registry_stats=registry_stats,
         datadir=datadir,
         self_shutdown=False,
@@ -196,9 +198,11 @@ def start(port: int, registry_stats: bool, datadir: Optional[Path] = None):
 )
 def stop(port):
     from ray_on_golem.client import RayOnGolemClient
+    from ray_on_golem.ctl import RayOnGolemCtl
+    from ray_on_golem.ctl.log import RayOnGolemCtlConsoleLogger
 
-    client = RayOnGolemClient(port)
-    client.stop_webserver()
+    ctl = RayOnGolemCtl(RayOnGolemClient(port), RayOnGolemCtlConsoleLogger())
+    ctl.stop_webserver()
 
 
 if __name__ == "__main__":

--- a/ray_on_golem/server/main.py
+++ b/ray_on_golem/server/main.py
@@ -16,6 +16,7 @@ from ray_on_golem.server.settings import (
     get_logging_config,
 )
 from ray_on_golem.server.views import routes
+from ray_on_golem.provider.node_provider import GolemNodeProvider
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ logger = logging.getLogger(__name__)
     help="Port for Ray on Golem's webserver to listen on.",
 )
 @click.option(
-    "--self-shutdown",
+    "--self-shutdown/--no-self-shutdown",
     is_flag=True,
     help="Enable self-shutdown after last node termination.",
 )
@@ -166,8 +167,12 @@ async def ray_service_ctx(app: web.Application) -> None:
     default=True,
     help="Enable collection of Golem Registry stats about resolved images.",
 )
-def start():
-    raise NotImplementedError()
+def start(port: int, registry_stats: bool, datadir: pathlib.Path):
+    GolemNodeProvider._get_ray_on_golem_client_instance(
+        webserver_port=port,
+        enable_registry_stats=registry_stats,
+        datadir=datadir,
+    )
 
 def stop():
     raise NotImplementedError()

--- a/ray_on_golem/server/main.py
+++ b/ray_on_golem/server/main.py
@@ -16,7 +16,6 @@ from ray_on_golem.server.settings import (
     get_logging_config,
 )
 from ray_on_golem.server.views import routes
-from ray_on_golem.provider.node_provider import GolemNodeProvider
 
 logger = logging.getLogger(__name__)
 
@@ -168,6 +167,8 @@ async def ray_service_ctx(app: web.Application) -> None:
     help="Enable collection of Golem Registry stats about resolved images.",
 )
 def start(port: int, registry_stats: bool, datadir: pathlib.Path):
+    from ray_on_golem.provider.node_provider import GolemNodeProvider
+
     GolemNodeProvider._get_ray_on_golem_client_instance(
         webserver_port=port,
         enable_registry_stats=registry_stats,

--- a/ray_on_golem/server/main.py
+++ b/ray_on_golem/server/main.py
@@ -5,6 +5,7 @@ import pathlib
 import click
 from aiohttp import web
 
+from ray_on_golem.client import RayOnGolemClient
 from ray_on_golem.server.middlewares import error_middleware, trace_id_middleware
 from ray_on_golem.server.services import GolemService, RayService, YagnaService
 from ray_on_golem.server.settings import (
@@ -167,16 +168,30 @@ async def ray_service_ctx(app: web.Application) -> None:
     help="Enable collection of Golem Registry stats about resolved images.",
 )
 def start(port: int, registry_stats: bool, datadir: pathlib.Path):
-    from ray_on_golem.provider.node_provider import GolemNodeProvider
-
-    GolemNodeProvider._get_ray_on_golem_client_instance(
+    RayOnGolemClient.get_instance(
         webserver_port=port,
         enable_registry_stats=registry_stats,
         datadir=datadir,
     )
 
-def stop():
-    raise NotImplementedError()
+
+@click.command(
+    help="Stop Ray on Golem's webserver and the yagna daemon, if it was started by the webserver.",
+    context_settings={"show_default": True},
+)
+@click.option(
+    "-p",
+    "--port",
+    type=int,
+    default=4578,
+    help="Port for Ray on Golem's webserver to listen on.",
+)
+def stop(port):
+    RayOnGolemClient.get_instance(
+        webserver_port=port,
+        start_webserver=False,
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/ray_on_golem/server/main.py
+++ b/ray_on_golem/server/main.py
@@ -176,7 +176,7 @@ def start(port: int, registry_stats: bool, datadir: pathlib.Path):
 
 
 @click.command(
-    help="Stop Ray on Golem's webserver and the yagna daemon, if it was started by the webserver.",
+    help="Stop Ray on Golem's webserver and the yagna daemon.",
     context_settings={"show_default": True},
 )
 @click.option(

--- a/ray_on_golem/server/models.py
+++ b/ray_on_golem/server/models.py
@@ -173,6 +173,10 @@ class GetOrCreateDefaultSshKeyResponseData(BaseModel):
     ssh_key_base64: str
 
 
+class GetDataDirectoryResponseData(BaseModel):
+    datadir: str
+
+
 class SelfShutdownRequestData(BaseModel):
     pass
 

--- a/ray_on_golem/server/models.py
+++ b/ray_on_golem/server/models.py
@@ -173,10 +173,6 @@ class GetOrCreateDefaultSshKeyResponseData(BaseModel):
     ssh_key_base64: str
 
 
-class GetDataDirectoryResponseData(BaseModel):
-    datadir: str
-
-
 class SelfShutdownRequestData(BaseModel):
     pass
 
@@ -187,3 +183,9 @@ class SelfShutdownResponseData(BaseModel):
 
 class HealthCheckResponseData(BaseModel):
     is_shutting_down: bool
+
+
+class WebserverStatus(BaseModel):
+    version: str
+    datadir: str
+    shutting_down: bool

--- a/ray_on_golem/server/models.py
+++ b/ray_on_golem/server/models.py
@@ -170,7 +170,8 @@ class GetOrCreateDefaultSshKeyRequestData(BaseModel):
 
 
 class GetOrCreateDefaultSshKeyResponseData(BaseModel):
-    ssh_key_base64: str
+    ssh_private_key_base64: str
+    ssh_public_key_base64: str
 
 
 class SelfShutdownRequestData(BaseModel):

--- a/ray_on_golem/server/services/golem/golem.py
+++ b/ray_on_golem/server/services/golem/golem.py
@@ -422,5 +422,5 @@ class GolemService:
         return network_url.with_scheme("ws") / "net" / self._network.id / "tcp" / ip
 
     def _get_ssh_proxy_command(self, connection_uri: URL) -> str:
-        # Using single quotes for JWT token as double quotes are causing problems with CLI character escaping in ray
+        # Using single quotes for the authentication token as double quotes are causing problems with CLI character escaping in ray
         return f"{self._websocat_path} asyncstdio: {connection_uri}/22 --binary -H=Authorization:'Bearer {self._yagna_appkey}'"

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -175,7 +175,7 @@ class RayService:
         return node_id
 
     async def terminate_node(self, node_id: NodeId) -> Dict[NodeId, Dict]:
-        logger.info(f"Terminating `{node_id}` node...")
+        logger.info("Terminating node: %s", node_id)
 
         async with self._get_node_context(node_id) as node:  # type: Node
             node.state = NodeState.terminating
@@ -187,7 +187,7 @@ class RayService:
             node.state = NodeState.terminated
             node.activity = None
 
-            logger.info(f"Terminating `{node_id}` node done")
+            logger.info(f"Terminating node `%s` done", node_id)
 
             return {node.node_id: node.dict(exclude={"activity"})}
 

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -234,8 +234,9 @@ class RayService:
         async with self._get_node_context(node_id) as node:  # type: Node
             node.tags.update(tags)
 
-    async def get_or_create_default_ssh_key(self, cluster_name: str) -> str:
+    async def get_or_create_default_ssh_key(self, cluster_name: str) -> Tuple[str, str]:
         ssh_key_path = self._datadir / get_default_ssh_key_name(cluster_name)
+        ssk_public_key_path = ssh_key_path.with_suffix(".pub")
 
         if not ssh_key_path.exists():
             logger.info(f"Creating default ssh key for `{cluster_name}`...")
@@ -252,8 +253,8 @@ class RayService:
             )
 
         # TODO: async file handling
-        with ssh_key_path.open("r") as f:
-            return str(f.read())
+        with ssh_key_path.open("r") as priv_f, ssk_public_key_path.open("r") as pub_f:
+            return str(priv_f.read()), str(pub_f.read())
 
     def get_datadir(self) -> Path:
         return self._datadir

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -36,12 +36,12 @@ class RayService:
         ray_on_golem_port: int,
         golem_service: GolemService,
         yagna_service: YagnaService,
-        tmp_path: Path,
+        datadir: Path,
     ):
         self._ray_on_golem_port = ray_on_golem_port
         self._golem_service = golem_service
         self._yagna_service = yagna_service
-        self._tmp_path = tmp_path
+        self._datadir = datadir
 
         self._provider_config: Optional[ProviderConfigData] = None
         self._wallet_address: Optional[str] = None
@@ -235,7 +235,7 @@ class RayService:
             node.tags.update(tags)
 
     async def get_or_create_default_ssh_key(self, cluster_name: str) -> str:
-        ssh_key_path = self._tmp_path / get_default_ssh_key_name(cluster_name)
+        ssh_key_path = self._datadir / get_default_ssh_key_name(cluster_name)
 
         if not ssh_key_path.exists():
             logger.info(f"Creating default ssh key for `{cluster_name}`...")
@@ -254,6 +254,9 @@ class RayService:
         # TODO: async file handling
         with ssh_key_path.open("r") as f:
             return str(f.read())
+
+    def get_datadir(self) -> Path:
+        return self._datadir
 
     @asynccontextmanager
     async def _get_node_context(self, node_id: NodeId) -> Iterator[Node]:

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -1,11 +1,11 @@
 import os
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional, Literal
+from typing import Literal, Optional
 
 import appdirs
-
 from yarl import URL
+
 from ray_on_golem.version import get_version
 
 LOG_GROUP = f"Ray On Golem {get_version()}"

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -1,11 +1,44 @@
 import os
 from datetime import timedelta
 from pathlib import Path
-from typing import Dict, Optional, Literal
+from typing import Optional, Literal
 
 import appdirs
 
 from yarl import URL
+
+YAGNA_APPKEY = os.getenv("YAGNA_APPKEY")
+YAGNA_APPNAME = os.getenv("YAGNA_APPNAME", "ray-on-golem")
+YAGNA_API_URL = URL(os.getenv("YAGNA_API_URL", "http://127.0.0.1:7465"))
+YAGNA_START_DEADLINE = timedelta(minutes=2)
+YAGNA_FUND_DEADLINE = timedelta(minutes=2)
+YAGNA_CHECK_DEADLINE = timedelta(seconds=2)
+
+RAY_ON_GOLEM_START_DEADLINE = timedelta(minutes=5)
+RAY_ON_GOLEM_CHECK_DEADLINE = timedelta(seconds=2)
+RAY_ON_GOLEM_SHUTDOWN_DELAY = timedelta(seconds=30)
+RAY_ON_GOLEM_SHUTDOWN_DEADLINE = timedelta(seconds=30)
+
+URL_HEALTH_CHECK = "/health_check"
+URL_CREATE_CLUSTER = "/create_cluster"
+URL_NON_TERMINATED_NODES = "/non_terminated_nodes"
+URL_IS_RUNNING = "/is_running"
+URL_IS_TERMINATED = "/is_terminated"
+URL_NODE_TAGS = "/tags"
+URL_GET_CLUSTER_DATA = "/cluster_data"
+URL_INTERNAL_IP = "/internal_ip"
+URL_SET_NODE_TAGS = "/set_tags"
+URL_REQUEST_NODES = "/request_nodes"
+URL_TERMINATE_NODE = "/terminate"
+URL_GET_SSH_PROXY_COMMAND = "/ssh_proxy_command"
+URL_GET_OR_CREATE_DEFAULT_SSH_KEY = "/ger_or_create_default_ssh_key"
+URL_GET_DATADIR = "/get_datadir"
+URL_SELF_SHUTDOWN = "/self_shutdown"
+
+PAYMENT_NETWORK_MAINNET = "mainnet"
+PAYMENT_NETWORK_POLYGON = "polygon"
+PAYMENT_NETWORK_GOERLI = "goerli"
+PAYMENT_DRIVER_ERC20 = "erc20"
 
 APPLICATION_NAME = "ray_on_golem"
 APPLICATION_AUTHOR = "golemfactory"
@@ -112,36 +145,3 @@ def get_logging_config(datadir: Optional[Path] = None):
             },
         },
     }
-
-YAGNA_APPKEY = os.getenv("YAGNA_APPKEY")
-YAGNA_APPNAME = os.getenv("YAGNA_APPNAME", "ray-on-golem")
-YAGNA_API_URL = URL(os.getenv("YAGNA_API_URL", "http://127.0.0.1:7465"))
-YAGNA_START_DEADLINE = timedelta(minutes=2)
-YAGNA_FUND_DEADLINE = timedelta(minutes=2)
-YAGNA_CHECK_DEADLINE = timedelta(seconds=2)
-
-RAY_ON_GOLEM_START_DEADLINE = timedelta(minutes=5)
-RAY_ON_GOLEM_CHECK_DEADLINE = timedelta(seconds=2)
-RAY_ON_GOLEM_SHUTDOWN_DELAY = timedelta(seconds=30)
-RAY_ON_GOLEM_SHUTDOWN_DEADLINE = timedelta(seconds=30)
-
-URL_HEALTH_CHECK = "/health_check"
-URL_CREATE_CLUSTER = "/create_cluster"
-URL_NON_TERMINATED_NODES = "/non_terminated_nodes"
-URL_IS_RUNNING = "/is_running"
-URL_IS_TERMINATED = "/is_terminated"
-URL_NODE_TAGS = "/tags"
-URL_GET_CLUSTER_DATA = "/cluster_data"
-URL_INTERNAL_IP = "/internal_ip"
-URL_SET_NODE_TAGS = "/set_tags"
-URL_REQUEST_NODES = "/request_nodes"
-URL_TERMINATE_NODE = "/terminate"
-URL_GET_SSH_PROXY_COMMAND = "/ssh_proxy_command"
-URL_GET_OR_CREATE_DEFAULT_SSH_KEY = "/ger_or_create_default_ssh_key"
-URL_GET_DATADIR = "/get_datadir"
-URL_SELF_SHUTDOWN = "/self_shutdown"
-
-PAYMENT_NETWORK_MAINNET = "mainnet"
-PAYMENT_NETWORK_POLYGON = "polygon"
-PAYMENT_NETWORK_GOERLI = "goerli"
-PAYMENT_DRIVER_ERC20 = "erc20"

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -19,7 +19,7 @@ RAY_ON_GOLEM_CHECK_DEADLINE = timedelta(seconds=2)
 RAY_ON_GOLEM_SHUTDOWN_DELAY = timedelta(seconds=30)
 RAY_ON_GOLEM_SHUTDOWN_DEADLINE = timedelta(seconds=30)
 
-URL_HEALTH_CHECK = "/health_check"
+URL_STATUS = "/"
 URL_CREATE_CLUSTER = "/create_cluster"
 URL_NON_TERMINATED_NODES = "/non_terminated_nodes"
 URL_IS_RUNNING = "/is_running"
@@ -32,7 +32,6 @@ URL_REQUEST_NODES = "/request_nodes"
 URL_TERMINATE_NODE = "/terminate"
 URL_GET_SSH_PROXY_COMMAND = "/ssh_proxy_command"
 URL_GET_OR_CREATE_DEFAULT_SSH_KEY = "/ger_or_create_default_ssh_key"
-URL_GET_DATADIR = "/get_datadir"
 URL_SELF_SHUTDOWN = "/self_shutdown"
 
 PAYMENT_NETWORK_MAINNET = "mainnet"
@@ -40,17 +39,19 @@ PAYMENT_NETWORK_POLYGON = "polygon"
 PAYMENT_NETWORK_GOERLI = "goerli"
 PAYMENT_DRIVER_ERC20 = "erc20"
 
-APPLICATION_NAME = "ray_on_golem"
-APPLICATION_AUTHOR = "golemfactory"
-
 RAY_ON_GOLEM_PATH = Path(os.getenv("RAY_ON_GOLEM_PATH", "ray-on-golem"))
-DEFAULT_DATADIR = Path(
-    os.getenv("RAY_ON_GOLEM_DATADIR", appdirs.user_data_dir(APPLICATION_NAME, APPLICATION_AUTHOR))
-)
 YAGNA_PATH = Path(os.getenv("YAGNA_PATH", "yagna"))
 WEBSOCAT_PATH = Path(os.getenv("WEBSOCAT_PATH", "websocat"))
 TMP_PATH = Path("/tmp/ray_on_golem")
 LOGGING_BACKUP_COUNT = 99
+
+APPLICATION_NAME = "ray_on_golem"
+APPLICATION_AUTHOR = "golemfactory"
+
+DEFAULT_DATADIR = Path(
+    os.getenv("RAY_ON_GOLEM_DATADIR", appdirs.user_data_dir(APPLICATION_NAME, APPLICATION_AUTHOR))
+)
+
 
 LogTypes = Literal["webserver", "webserver_debug", "yagna"]
 

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -6,6 +6,9 @@ from typing import Optional, Literal
 import appdirs
 
 from yarl import URL
+from ray_on_golem.version import get_version
+
+LOG_GROUP = f"Ray On Golem {get_version()}"
 
 YAGNA_APPKEY = os.getenv("YAGNA_APPKEY")
 YAGNA_APPNAME = os.getenv("YAGNA_APPNAME", "ray-on-golem")

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -6,10 +6,6 @@ from typing import Literal, Optional
 import appdirs
 from yarl import URL
 
-from ray_on_golem.version import get_version
-
-LOG_GROUP = f"Ray On Golem {get_version()}"
-
 YAGNA_APPKEY = os.getenv("YAGNA_APPKEY")
 YAGNA_APPNAME = os.getenv("YAGNA_APPNAME", "ray-on-golem")
 YAGNA_API_URL = URL(os.getenv("YAGNA_API_URL", "http://127.0.0.1:7465"))

--- a/ray_on_golem/server/views.py
+++ b/ray_on_golem/server/views.py
@@ -33,11 +33,13 @@ def json_response(model_obj: BaseModel) -> web.Response:
 @routes.view(settings.URL_STATUS)
 async def status(request: web.Request) -> web.Response:
     ray_service: RayService = request.app["ray_service"]
-    return json_response(models.WebserverStatus(
-        version=get_version(),
-        datadir=str(ray_service.get_datadir()),
-        shutting_down=request.app.get("shutting_down", False)
-    ))
+    return json_response(
+        models.WebserverStatus(
+            version=get_version(),
+            datadir=str(ray_service.get_datadir()),
+            shutting_down=request.app.get("shutting_down", False),
+        )
+    )
 
 
 @routes.post(settings.URL_CREATE_CLUSTER)
@@ -53,12 +55,14 @@ async def create_cluster(request: web.Request) -> web.Response:
         yagna_payment_status,
     ) = await ray_service.create_cluster(provider_config=request_data)
 
-    return json_response(models.CreateClusterResponseData(
-        is_cluster_just_created=is_cluster_just_created,
-        wallet_address=wallet_address,
-        yagna_payment_status_output=yagna_payment_status_output,
-        yagna_payment_status=yagna_payment_status,
-    ))
+    return json_response(
+        models.CreateClusterResponseData(
+            is_cluster_just_created=is_cluster_just_created,
+            wallet_address=wallet_address,
+            yagna_payment_status_output=yagna_payment_status_output,
+            yagna_payment_status=yagna_payment_status,
+        )
+    )
 
 
 @routes.post(settings.URL_NON_TERMINATED_NODES)

--- a/ray_on_golem/server/views.py
+++ b/ray_on_golem/server/views.py
@@ -188,11 +188,16 @@ async def get_or_create_ssh_key(request):
 
     request_data = models.GetOrCreateDefaultSshKeyRequestData.parse_raw(await request.text())
 
-    ssh_key_base64 = await ray_service.get_or_create_default_ssh_key(
+    priv, pub = await ray_service.get_or_create_default_ssh_key(
         cluster_name=request_data.cluster_name
     )
 
-    return json_response(models.GetOrCreateDefaultSshKeyResponseData(ssh_key_base64=ssh_key_base64))
+    return json_response(
+        models.GetOrCreateDefaultSshKeyResponseData(
+            ssh_private_key_base64=priv,
+            ssh_public_key_base64=pub,
+        )
+    )
 
 
 @routes.post(settings.URL_SELF_SHUTDOWN)

--- a/ray_on_golem/server/views.py
+++ b/ray_on_golem/server/views.py
@@ -25,7 +25,7 @@ def reject_if_shutting_down(func):
 
 # FIXME: This route should be a default root URL with basic server info instead of
 #  custom URL with custom payload
-@routes.get(settings.URL_HEALTH_CHECK)
+@routes.view(settings.URL_HEALTH_CHECK)
 async def health_check(request: web.Request) -> web.Response:
     response_data = models.HealthCheckResponseData(
         is_shutting_down=request.app.get("shutting_down", False)
@@ -206,6 +206,13 @@ async def get_or_create_ssh_key(request):
 
     response_data = models.GetOrCreateDefaultSshKeyResponseData(ssh_key_base64=ssh_key_base64)
 
+    return web.Response(text=response_data.json())
+
+
+@routes.view(settings.URL_GET_DATADIR)
+async def get_datadir(request):
+    ray_service: RayService = request.app["ray_service"]
+    response_data = models.GetDataDirectoryResponseData(datadir=ray_service.get_datadir())
     return web.Response(text=response_data.json())
 
 

--- a/ray_on_golem/utils.py
+++ b/ray_on_golem/utils.py
@@ -9,7 +9,6 @@ from typing import Dict
 from aiohttp.web_runner import GracefulExit
 
 from ray_on_golem.exceptions import RayOnGolemError
-from ray_on_golem.server.settings import TMP_PATH
 
 
 async def run_subprocess(
@@ -54,6 +53,7 @@ def are_dicts_equal(dict1: Dict, dict2: Dict) -> bool:
 
 
 def is_running_on_golem_network() -> bool:
+    """Detect if this code is being executed inside a VM on a provider node."""
     return os.getenv("ON_GOLEM_NETWORK") is not None
 
 
@@ -68,10 +68,3 @@ def raise_graceful_exit() -> None:
 def get_last_lines_from_file(file_path: Path, max_lines: int) -> str:
     with file_path.open() as file:
         return "".join(deque(file, max_lines))
-
-
-def prepare_tmp_dir():
-    try:
-        TMP_PATH.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        pass

--- a/tests/unit/provider/test_node_provider.py
+++ b/tests/unit/provider/test_node_provider.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 import yaml
 
+from ray_on_golem.client import RayOnGolemClient
 from ray_on_golem.provider.node_provider import GolemNodeProvider
 from ray_on_golem.server.models import ProviderConfigData
 
@@ -21,7 +22,7 @@ CLUSTER_CONFIG_STUB = {
 
 @pytest.fixture
 def disable_webserver(monkeypatch):
-    monkeypatch.setattr(GolemNodeProvider, "_get_ray_on_golem_client_instance", mock.Mock())
+    monkeypatch.setattr(RayOnGolemClient, "get_instance", mock.Mock())
 
 
 @pytest.fixture

--- a/tests/unit/provider/test_node_provider.py
+++ b/tests/unit/provider/test_node_provider.py
@@ -26,8 +26,9 @@ def disable_webserver(monkeypatch):
 
 
 @pytest.fixture
-def mock_path_open(monkeypatch):
+def patch_path(monkeypatch):
     monkeypatch.setattr(Path, "open", mock.MagicMock())
+    monkeypatch.setattr(Path, "exists", mock.Mock(return_value=True))
 
 
 @pytest.mark.parametrize(
@@ -38,7 +39,7 @@ def mock_path_open(monkeypatch):
         CLUSTER_CONFIG_STUB,
     ),
 )
-def test_node_provider_defaults(disable_webserver, mock_path_open, cluster_config):
+def test_node_provider_defaults(disable_webserver, patch_path, cluster_config):
     resolved_config = GolemNodeProvider.bootstrap_config(cluster_config)
 
     provider_params = resolved_config["provider"]["parameters"]

--- a/tests/unit/provider/test_node_provider.py
+++ b/tests/unit/provider/test_node_provider.py
@@ -22,7 +22,7 @@ CLUSTER_CONFIG_STUB = {
 
 @pytest.fixture
 def disable_webserver(monkeypatch):
-    monkeypatch.setattr(RayOnGolemClient, "get_instance", mock.Mock())
+    monkeypatch.setattr(RayOnGolemClient, "start_webserver", mock.Mock())
 
 
 @pytest.fixture

--- a/tests/unit/provider/test_node_provider.py
+++ b/tests/unit/provider/test_node_provider.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 import yaml
 
-from ray_on_golem.client import RayOnGolemClient
+from ray_on_golem.ctl.ctl import RayOnGolemCtl
 from ray_on_golem.provider.node_provider import GolemNodeProvider
 from ray_on_golem.server.models import ProviderConfigData
 
@@ -22,7 +22,7 @@ CLUSTER_CONFIG_STUB = {
 
 @pytest.fixture
 def disable_webserver(monkeypatch):
-    monkeypatch.setattr(RayOnGolemClient, "start_webserver", mock.Mock())
+    monkeypatch.setattr(RayOnGolemCtl, "start_webserver", mock.Mock())
 
 
 @pytest.fixture


### PR DESCRIPTION
* add webserver `start` command
* add webserver `stop` command
* add option to select the data directory which ray-on-golem uses
* change the default data/log directory from `/tmp` to user's default application data directory
* optimize RayOnGolemClient's calls
* move webserver start/stop/etc routines from the `GolemNodeProvider` to `RayOnGolemClient`

closes #173