### PR TITLE
Support `node_config` per node type in yaml

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           PYTHONUNBUFFERED: 1
           RUST_LOG: "INFO,ya_erc20_driver::erc20::wallet=debug"
-        run: poetry run ray up golem-cluster.tests.yaml -y
+        run: poetry run ray up golem-cluster.tests.yaml -y --no-config-cache
 
       - name: Run `examples/calculate.pi`
         run: poetry run ray submit golem-cluster.tests.yaml examples/calculate_pi.py

--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -39,9 +39,12 @@ jobs:
       - name: Call `ray down`
         run: poetry run ray down golem-cluster.tests.yaml -y
 
+      - name: Call `ray-on-golem down`
+        run: poetry run ray-on-golem stop
+
       - name: Check node creation in logs
         continue-on-error: true
-        run: poetry run python tests/smoke.py ~/.local/share/ray_on_golem/
+        run: poetry run python tests/smoke.py ~/.local/share/ray_on_golem/webserver_debug.log
 
       - name: Collects logs
         if: always()

--- a/golem-cluster.override.2-image.yaml
+++ b/golem-cluster.override.2-image.yaml
@@ -2,4 +2,4 @@ provider:
   parameters:
     node_config:
       demand:
-        image_tag: "blueshade/ray-on-golem:0.8.0-dev-py3.10.13-ray2.9.2"
+        image_tag: "approxit/ray-on-golem:0.8.0-dev-py3.10.13-ray2.9.2"

--- a/golem-cluster.override.5-subnet.yaml
+++ b/golem-cluster.override.5-subnet.yaml
@@ -1,3 +1,4 @@
 provider:
   parameters:
-    subnet_tag: "sdk"
+    node_config:
+      subnet_tag: "public"

--- a/golem-cluster.override.5-subnet.yaml
+++ b/golem-cluster.override.5-subnet.yaml
@@ -1,4 +1,4 @@
 provider:
   parameters:
     node_config:
-      subnet_tag: "public"
+      subnet_tag: "sdk"

--- a/golem-cluster.yaml
+++ b/golem-cluster.yaml
@@ -25,6 +25,7 @@ provider:
     # Maximum amount of GLMs that's going to be spent for the whole cluster
     total_budget: 5
 
+    # Common parameters for all node types. Can be overriden in available_node_types
     node_config:
       # Parameters for golem demands (same for head and workers)
       demand:
@@ -100,7 +101,9 @@ available_node_types:
     # The node type's CPU and GPU resources
     resources: {}
 
-    node_config: {} # TODO: Demand description here
+    # Additional parameters specific for this node type added on top of node_config from provider.parameters.node_config
+    node_config: {}
+
   ray.worker.default:
     min_workers: 1
     max_workers: 10

--- a/golem-cluster.yaml
+++ b/golem-cluster.yaml
@@ -103,6 +103,9 @@ available_node_types:
 
     # Additional parameters specific for this node type added on top of node_config from provider.parameters.node_config
     node_config: {}
+    #node_config:
+    #  demand:
+    #    min_mem_gib: 10
 
   ray.worker.default:
     min_workers: 1
@@ -111,10 +114,10 @@ available_node_types:
     node_config: {}
 
 # List of commands that will be run to initialize the nodes (before `setup_commands`)
+initialization_commands: []
 #initialization_commands: [
 #  "pip install endplay",
 #]
-initialization_commands: []
 
 # List of shell commands to run to set up nodes
 setup_commands: []

--- a/ray_on_golem/network_stats/services/network_stats.py
+++ b/ray_on_golem/network_stats/services/network_stats.py
@@ -16,7 +16,7 @@ from golem.managers import (
     ProposalScoringBuffer,
     RefreshingDemandManager,
 )
-from golem.managers.base import ManagerPluginException, ProposalNegotiator
+from golem.managers.base import ManagerPluginException, PaymentManager, ProposalNegotiator
 from golem.node import GolemNode
 from golem.resources import DemandData, Proposal
 from golem.resources.proposal.exceptions import ProposalRejected
@@ -123,6 +123,8 @@ class NetworkStatsService:
 
         self._stats_plugin_factory = StatsPluginFactory()
 
+        self._payment_manager: Optional[PaymentManager] = None
+
     async def init(self, yagna_appkey: str) -> None:
         logger.info("Starting NetworkStatsService...")
 
@@ -140,16 +142,17 @@ class NetworkStatsService:
 
         logger.info("Stopping NetworkStatsService done")
 
-    async def run(self, provider_parameters: Dict, duration_minutes: int) -> None:
+    async def run(self, config: Dict, node_type: str, duration_minutes: int) -> None:
+        provider_parameters: Dict = config["provider"]["parameters"]
+
         payment_network: str = provider_parameters["payment_network"]
         total_budget: float = provider_parameters["total_budget"]
-        subnet_tag: str = provider_parameters["subnet_tag"]
-        node_config: NodeConfigData = NodeConfigData(**provider_parameters["node_config"])
+        node_config = NodeConfigData(**config["available_node_types"][node_type]["node_config"])
 
-        stack = await self._create_stack(node_config, total_budget, payment_network, subnet_tag)
+        stack = await self._create_stack(node_config, total_budget, payment_network)
         await stack.start()
 
-        print(f"Gathering stats data for {duration_minutes} minutes...")
+        print(f"Gathering stats data for {duration_minutes} minutes for `{node_type}`...")
         consume_proposals_task = asyncio.create_task(self._consume_draft_proposals(stack))
         try:
             await asyncio.wait(
@@ -161,6 +164,8 @@ class NetworkStatsService:
             await consume_proposals_task
 
             await stack.stop()
+            await self._payment_manager.stop()
+            self._payment_manager = None
             print("Gathering stats data done")
             self._stats_plugin_factory.print_gathered_stats()
 
@@ -184,8 +189,13 @@ class NetworkStatsService:
         node_config: NodeConfigData,
         total_budget: float,
         payment_network: str,
-        subnet_tag: str,
     ) -> ManagerStack:
+        if not self._payment_manager:
+            self._payment_manager = PayAllPaymentManager(
+                self._golem, budget=total_budget, network=payment_network
+            )
+            await self._payment_manager.start()
+
         stack = ManagerStack()
 
         payloads = await self._demand_config_helper.get_payloads_from_demand_config(
@@ -195,15 +205,12 @@ class NetworkStatsService:
         ManagerStackNodeConfigHelper.apply_budget_control_expected_usage(stack, node_config)
         ManagerStackNodeConfigHelper.apply_budget_control_hard_limits(stack, node_config)
 
-        stack.payment_manager = PayAllPaymentManager(
-            self._golem, budget=total_budget, network=payment_network
-        )
         stack.demand_manager = RefreshingDemandManager(
             self._golem,
-            stack.payment_manager.get_allocation,
+            self._payment_manager.get_allocation,
             payloads,
             demand_lifetime=timedelta(hours=8),
-            subnet_tag=subnet_tag,
+            subnet_tag=node_config.subnet_tag,
         )
 
         plugins = [

--- a/ray_on_golem/server/models.py
+++ b/ray_on_golem/server/models.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from golem.resources import Activity
 from pydantic import AnyUrl, BaseModel, Field, validator
 
 NodeId = str
@@ -32,10 +31,7 @@ class NodeData(BaseModel):
 
 
 class Node(NodeData):
-    activity: Optional[Activity] = None
-
-    class Config:
-        arbitrary_types_allowed = True
+    activity_id: Optional[str] = None
 
 
 class SingleNodeRequestData(BaseModel):
@@ -90,6 +86,7 @@ class BudgetControlData(BaseModel):
 
 
 class NodeConfigData(BaseModel):
+    subnet_tag: str
     demand: DemandConfigData = Field(default_factory=DemandConfigData)
     budget_control: Optional[BudgetControlData] = Field(default_factory=BudgetControlData)
 
@@ -101,7 +98,6 @@ class ProviderConfigData(BaseModel):
     node_config: NodeConfigData
     ssh_private_key: str
     ssh_user: str
-    subnet_tag: str
 
 
 class CreateClusterRequestData(ProviderConfigData):

--- a/ray_on_golem/server/models.py
+++ b/ray_on_golem/server/models.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import AnyUrl, BaseModel, Field, validator
 
+from golem.resources import Activity
+
 NodeId = str
 Tags = Dict[str, str]
 
@@ -31,7 +33,10 @@ class NodeData(BaseModel):
 
 
 class Node(NodeData):
-    activity_id: Optional[str] = None
+    activity: Optional[Activity] = None
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 class SingleNodeRequestData(BaseModel):

--- a/ray_on_golem/server/models.py
+++ b/ray_on_golem/server/models.py
@@ -1,9 +1,8 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import AnyUrl, BaseModel, Field, validator
-
 from golem.resources import Activity
+from pydantic import AnyUrl, BaseModel, Field, validator
 
 NodeId = str
 Tags = Dict[str, str]

--- a/ray_on_golem/server/services/golem/manager_stack.py
+++ b/ray_on_golem/server/services/golem/manager_stack.py
@@ -5,7 +5,6 @@ from golem.managers import (
     ActivityManager,
     AgreementManager,
     DemandManager,
-    PaymentManager,
     ProposalManager,
     ProposalManagerPlugin,
     ProposalScorer,
@@ -16,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 class ManagerStack(BaseModel):
-    payment_manager: Optional[PaymentManager]
     demand_manager: Optional[DemandManager]
     proposal_manager: Optional[ProposalManager]
     agreement_manager: Optional[AgreementManager]
@@ -30,7 +28,6 @@ class ManagerStack(BaseModel):
     @property
     def _managers(self):
         return [
-            self.payment_manager,
             self.demand_manager,
             self.proposal_manager,
             self.agreement_manager,

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -155,6 +155,8 @@ class RayService:
         return created_node_ids
 
     async def _create_node(self, node_id: NodeId, node_config: NodeConfigData) -> None:
+        logger.info("Creating node `%s`...", node_id)
+
         try:
             activity, ip, ssh_proxy_command = await self._golem_service.create_activity(
                 node_config=node_config,
@@ -186,6 +188,8 @@ class RayService:
         finally:
             self._create_node_tasks.remove(asyncio.current_task())
 
+        logger.info("Creating node `%s` done", node_id)
+
     async def _add_node_state_log(self, node_id: NodeId, log_entry: str) -> None:
         async with self._get_node_context(node_id) as node:  # type: Node
             node.state_log.append(log_entry)
@@ -196,7 +200,7 @@ class RayService:
         return node_id
 
     async def terminate_node(self, node_id: NodeId) -> Dict[NodeId, Dict]:
-        logger.info("Terminating node: %s", node_id)
+        logger.info("Terminating node `%s`...", node_id)
 
         async with self._get_node_context(node_id) as node:  # type: Node
             node.state = NodeState.terminating

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -1,10 +1,10 @@
 import re
 import sys
 
-creating_re = re.compile(r".*] Creating ([0-9]+) nodes\.\.\..*")
-created_re = re.compile(r".*] Creating ([0-9]+) nodes done.*")
-terminating_re = re.compile(r".*] Terminating `[^`]+` node\.\.\..*")
-terminated_re = re.compile(r".*] Terminating `[^`]+` node done.*")
+creating_re = re.compile(r".*] Creating node `[^`]+`\.\.\..*")
+created_re = re.compile(r".*] Creating node `[^`]+` done.*")
+terminating_re = re.compile(r".*] Terminating node `[^`]+`\.\.\..*")
+terminated_re = re.compile(r".*] Terminating node `[^`]+` done.*")
 
 creating_count = 0
 created_count = 0
@@ -15,11 +15,11 @@ with open(sys.argv[1]) as file:
     for line in file:
         match = creating_re.match(line)
         if match:
-            creating_count += int(match.groups()[0])
+            creating_count += 1
 
         match = created_re.match(line)
         if match:
-            created_count += int(match.groups()[0])
+            created_count += 1
 
         match = terminating_re.match(line)
         if match:
@@ -46,6 +46,9 @@ if created_count != terminated_count:
         f"Logs contains miss-matched logs between node creation and termination level: created={created_count} "
         f"terminated={terminated_count}"
     )
+
+if not created_count:
+    errors.append("No creation entries found in log file!")
 
 if errors:
     print("Errors:", file=sys.stderr)


### PR DESCRIPTION
What I've done:
- Moved `subnet_tag` to be part of the `node_config` instead of `provider.parameters` as the subnet now can differ from node type to node type.
- Made manager stacks to be based on `available_node_types.<node type>.node_config` and not on `provider.parameters.node_config`.
- Made config bootstrapping to populate `available_node_types.<node type>.node_config` with defaults from `provider.parameters.node_config`, so common settings declared in `provider.parameters.node_config` will be shared/copied over to all node types.
- Removed explicit server shutdown in `NodeProvider.terminate_node` in favor of closing unused manager stack on the webserver side while calling that function.
- Pulled out the payment manager from the manager stack, as it is common for the whole cluster, not per manager stack.
- Made `GolemService` to track which activity uses which stack, and expose activity_id instead of raw activity to help with tracking safety.
- Made `network_stats` entry point to be based on a specific node type, as each node type could have different market settings
- Updated ray version to `2.9.2` and cleaned up / normalized the dependencies.
- Updated gvmi image

Notable remarks:
- Somehow, once again, exiting the webserver waits to timeout instead of exiting right away... this should be somehow investigated and fixed.