### PR TITLE
Fix exception retrial

### DIFF
--- a/ray_on_golem/server/services/golem/golem.py
+++ b/ray_on_golem/server/services/golem/golem.py
@@ -437,7 +437,7 @@ class GolemService:
 
             await self._network.refresh_nodes()
         except Exception as e:
-            logger.error(f"Creating new activity failed with `{e}`")
+            logger.error(f"Creating new activity failed with `{type(e).__name__}: {e}`")
             await activity.destroy()
             raise
 

--- a/ray_on_golem/server/services/golem/golem.py
+++ b/ray_on_golem/server/services/golem/golem.py
@@ -7,6 +7,7 @@ from functools import partial
 from pathlib import Path
 from typing import Awaitable, Callable, Dict, Optional, Tuple
 
+from golem.exceptions import GolemException
 from golem.managers import (
     BlacklistProviderIdPlugin,
     DefaultAgreementManager,
@@ -381,10 +382,9 @@ class GolemService:
                     ssh_private_key_path,
                     add_state_log=add_state_log,
                 )
-
             except (ManagerException,):
                 raise
-            except Exception as e:
+            except (GolemException,) as e:
                 msg = "Failed to create activity, retrying."
                 error = f"{type(e).__module__}.{type(e).__name__}: {e}"
                 await add_state_log(f"{msg} {error=}")

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -184,7 +184,9 @@ class RayService:
         except Exception as e:
             async with self._get_node_context(node_id) as node:  # type: Node
                 node.state = NodeState.terminated
-                node.state_log.append(f"Failed to create activity: {type(e).__name__}({e})")
+                node.state_log.append(
+                    f"Failed to create activity: {type(e).__module__}.{type(e).__name__}: {e}"
+                )
         finally:
             self._create_node_tasks.remove(asyncio.current_task())
 


### PR DESCRIPTION
Fixes: #183 

Issue:
* when an error happens when creating activity, the activity won't be retried on another provider but instead, `ray up` will exit with failure
* plus, when the error is displayed, it's the exception class path so it's harder to figure out where to look for the cause

This pull request addresses both issues -> reinstates retrial and gives better information when failures happen