### PR TITLE
Suggested heads support

### DIFF
--- a/golem-cluster.mini.yaml
+++ b/golem-cluster.mini.yaml
@@ -15,10 +15,6 @@ provider:
       demand:
         image_tag: "golem/ray-on-golem:0.7.0-py3.10.13-ray2.7.1"
 
-file_mounts: {
-  # <remote_path>: <local_path>
-}
-
 # Tells the autoscaler the allowed node types and the resources they provide
 available_node_types:
   ray.head.default:
@@ -28,6 +24,13 @@ available_node_types:
   ray.worker.default:
     resources: {}
     node_config: {}
+
+# Specify the node type of the head node (as configured above).
+head_node_type: ray.head.default
+
+file_mounts: {
+  # <remote_path>: <local_path>
+}
 
 # List of commands that will be run to initialize the nodes (before `setup_commands`)
 initialization_commands: []

--- a/golem-cluster.override.5-subnet.yaml
+++ b/golem-cluster.override.5-subnet.yaml
@@ -1,4 +1,5 @@
 provider:
   parameters:
     node_config:
-      subnet_tag: "sdk"
+      subnet_tag: "public"
+      priority_head_subnet_tag: "sdk"

--- a/golem-cluster.override.5-subnet.yaml
+++ b/golem-cluster.override.5-subnet.yaml
@@ -1,4 +1,4 @@
 provider:
   parameters:
     node_config:
-      subnet_tag: "sdk"
+      subnet_tag: "public"

--- a/golem-cluster.override.5-subnet.yaml
+++ b/golem-cluster.override.5-subnet.yaml
@@ -1,4 +1,4 @@
 provider:
   parameters:
     node_config:
-      subnet_tag: "public"
+      subnet_tag: "sdk"

--- a/golem-cluster.yaml
+++ b/golem-cluster.yaml
@@ -75,20 +75,6 @@ provider:
           minimal: 1
           optimal: 12 # optional defaults to `minimal`
 
-# The files or directories to copy to the head and worker nodes
-# Remote workdir is /root/
-file_mounts: {
-  # <remote_path>: <local_path>
-  # "/absolute/path/dir/": ".",
-  # "./relative/path/dir/": ".",
-  # "./relative/path/file.txt": "./file.txt"
-}
-
-# Satisfy checks to disable warning about legacy fields at `ray up`.
-# This will be removed by ray-on-golem on the fly.
-head_node: True
-worker_nodes: True
-
 # Tells the autoscaler the allowed node types and the resources they provide
 available_node_types:
   ray.head.default:
@@ -112,6 +98,23 @@ available_node_types:
     max_workers: 10
     resources: {}
     node_config: {}
+
+# Specify the node type of the head node (as configured above).
+head_node_type: ray.head.default
+
+# Satisfy checks to disable warning about legacy fields at `ray up`.
+# This will be removed by ray-on-golem on the fly.
+head_node: True
+worker_nodes: True
+
+# The files or directories to copy to the head and worker nodes
+# Remote workdir is /root/
+file_mounts: {
+  # <remote_path>: <local_path>
+  # "/absolute/path/dir/": ".",
+  # "./relative/path/dir/": ".",
+  # "./relative/path/file.txt": "./file.txt"
+}
 
 # List of commands that will be run to initialize the nodes (before `setup_commands`)
 initialization_commands: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python = "^3.8.1"
 
 ray = {version="^2.9.2", extras=["default"]}
 #golem-core = {path="../golem-core-python", develop=true}
-golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="approxit/suggested-heads"}
+golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="main"}
 #golem-core = "^0.5.0"
 aiohttp = "^3"
 requests = "^2"
@@ -31,7 +31,7 @@ python = "^3.8.1"
 
 ray = {version="==2.9.2", extras=["default"]}
 #golem-core = {path="../golem-core-python", develop=true}
-golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="approxit/suggested-heads"}
+golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="main"}
 #golem-core = "^0.5.0"
 aiohttp = "^3"
 requests = "^2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python = "^3.8.1"
 
 ray = {version="^2.9.2", extras=["default"]}
 #golem-core = {path="../golem-core-python", develop=true}
-golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="approxit/suggested-head"}
+golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="approxit/suggested-heads"}
 #golem-core = "^0.5.0"
 aiohttp = "^3"
 requests = "^2"
@@ -31,7 +31,7 @@ python = "^3.8.1"
 
 ray = {version="==2.9.2", extras=["default"]}
 #golem-core = {path="../golem-core-python", develop=true}
-golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="approxit/suggested-head"}
+golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="approxit/suggested-heads"}
 #golem-core = "^0.5.0"
 aiohttp = "^3"
 requests = "^2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ packages = [{include = "ray_on_golem"}]
 python = "^3.8.1"
 
 ray = {version="^2.9.2", extras=["default"]}
-# golem-core = { path="../golem-core-python", develop=true }
-# golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="main"}
-golem-core = "^0.5.0"
+golem-core = {path="../golem-core-python", develop=true}
+#golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="main"}
+#golem-core = "^0.5.0"
 aiohttp = "^3"
 requests = "^2"
 click = "^8"
@@ -30,9 +30,9 @@ setuptools = "*"
 python = "^3.8.1"
 
 ray = {version="==2.9.2", extras=["default"]}
-# golem-core = { path="../golem-core-python", develop=true }
-# golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="main"}
-golem-core = "^0.5.0"
+golem-core = {path="../golem-core-python", develop=true}
+#golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="main"}
+#golem-core = "^0.5.0"
 aiohttp = "^3"
 requests = "^2"
 click = "^8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ packages = [{include = "ray_on_golem"}]
 python = "^3.8.1"
 
 ray = {version="^2.9.2", extras=["default"]}
-golem-core = {path="../golem-core-python", develop=true}
-#golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="main"}
+#golem-core = {path="../golem-core-python", develop=true}
+golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="approxit/suggested-head"}
 #golem-core = "^0.5.0"
 aiohttp = "^3"
 requests = "^2"
@@ -30,8 +30,8 @@ setuptools = "*"
 python = "^3.8.1"
 
 ray = {version="==2.9.2", extras=["default"]}
-golem-core = {path="../golem-core-python", develop=true}
-#golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="main"}
+#golem-core = {path="../golem-core-python", develop=true}
+golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="approxit/suggested-head"}
 #golem-core = "^0.5.0"
 aiohttp = "^3"
 requests = "^2"

--- a/ray_on_golem/provider/node_provider.py
+++ b/ray_on_golem/provider/node_provider.py
@@ -45,6 +45,7 @@ PROVIDER_DEFAULTS = {
     "payment_driver": PAYMENT_DRIVER_ERC20,
     "node_config": {
         "subnet_tag": "public",
+        "priority_head_subnet_tag": "ray-on-golem-heads",
     },
     "total_budget": 1.0,
 }

--- a/ray_on_golem/server/main.py
+++ b/ray_on_golem/server/main.py
@@ -123,7 +123,9 @@ async def startup_print(app: web.Application) -> None:
 
 async def shutdown_print(app: web.Application) -> None:
     print("")  # explicit new line to console to visually better handle ^C
-    logger.info("Waiting up to `%s` for current connections to close...", RAY_ON_GOLEM_SHUTDOWN_TIMEOUT)
+    logger.info(
+        "Waiting up to `%s` for current connections to close...", RAY_ON_GOLEM_SHUTDOWN_TIMEOUT
+    )
 
 
 async def yagna_service_ctx(app: web.Application) -> None:

--- a/ray_on_golem/server/main.py
+++ b/ray_on_golem/server/main.py
@@ -123,7 +123,7 @@ async def startup_print(app: web.Application) -> None:
 
 async def shutdown_print(app: web.Application) -> None:
     print("")  # explicit new line to console to visually better handle ^C
-    logger.info("Stopping server gracefully, forcing after `%s`...", RAY_ON_GOLEM_SHUTDOWN_TIMEOUT)
+    logger.info("Waiting up to `%s` for current connections to close...", RAY_ON_GOLEM_SHUTDOWN_TIMEOUT)
 
 
 async def yagna_service_ctx(app: web.Application) -> None:

--- a/ray_on_golem/server/models.py
+++ b/ray_on_golem/server/models.py
@@ -91,6 +91,7 @@ class BudgetControlData(BaseModel):
 
 class NodeConfigData(BaseModel):
     subnet_tag: str
+    priority_head_subnet_tag: Optional[str]
     demand: DemandConfigData = Field(default_factory=DemandConfigData)
     budget_control: Optional[BudgetControlData] = Field(default_factory=BudgetControlData)
 

--- a/ray_on_golem/server/services/golem/golem.py
+++ b/ray_on_golem/server/services/golem/golem.py
@@ -1,11 +1,10 @@
 import asyncio
-import hashlib
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from pathlib import Path
-from typing import Awaitable, Callable, Dict, Optional, Tuple, DefaultDict
+from typing import Awaitable, Callable, DefaultDict, Dict, Optional, Tuple
 
 from golem.exceptions import GolemException
 from golem.managers import (

--- a/ray_on_golem/server/services/golem/helpers/manager_stack.py
+++ b/ray_on_golem/server/services/golem/helpers/manager_stack.py
@@ -95,21 +95,27 @@ class ManagerStackNodeConfigHelper:
             logger.debug("Budget control based on max limits is not enabled")
 
     @classmethod
-    def apply_priority_head_node_scoring(cls, extra_proposal_scorers: Dict[str, ProposalScorer],
-        node_config: NodeConfigData,):
+    def apply_priority_head_node_scoring(
+        cls,
+        extra_proposal_scorers: Dict[str, ProposalScorer],
+        node_config: NodeConfigData,
+    ):
         if not node_config.priority_head_subnet_tag:
             return
 
-        extra_proposal_scorers['Extra score for priority head node'] = MapScore(
+        extra_proposal_scorers["Extra score for priority head node"] = MapScore(
             partial(
-                cls._score_suggested_heads, priority_head_subnet_tag=node_config.priority_head_subnet_tag
+                cls._score_suggested_heads,
+                priority_head_subnet_tag=node_config.priority_head_subnet_tag,
             )
         )
 
     @staticmethod
-    def _score_suggested_heads(proposal_data: ProposalData, priority_head_subnet_tag: Optional[str]) -> Optional[float]:
-        add_scoring = (
-            priority_head_subnet_tag and (proposal_data.properties.get("golem.node.debug.subnet") == priority_head_subnet_tag)
+    def _score_suggested_heads(
+        proposal_data: ProposalData, priority_head_subnet_tag: Optional[str]
+    ) -> Optional[float]:
+        add_scoring = priority_head_subnet_tag and (
+            proposal_data.properties.get("golem.node.debug.subnet") == priority_head_subnet_tag
         )
 
         return 0.5 if add_scoring else 0

--- a/ray_on_golem/server/services/golem/helpers/manager_stack.py
+++ b/ray_on_golem/server/services/golem/helpers/manager_stack.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import Dict, List, Optional
 
 from golem.managers import (
+    AggregatingDemandManager,
     DemandManager,
     LinearCoeffsCost,
     LinearPerCpuAverageCostPricing,
@@ -14,7 +15,6 @@ from golem.managers import (
     RefreshingDemandManager,
     RejectIfCostsExceeds,
 )
-from golem.managers.demand.union import UnionDemandManager
 from golem.node import GolemNode
 from golem.payload import Payload
 from golem.resources import ProposalData
@@ -152,7 +152,7 @@ class ManagerStackNodeConfigHelper:
             )
 
             demand_manager = stack.add_manager(
-                UnionDemandManager(
+                AggregatingDemandManager(
                     golem_node,
                     [
                         suggested_heads_demand_manager.get_initial_proposal,

--- a/ray_on_golem/server/services/golem/manager_stack.py
+++ b/ray_on_golem/server/services/golem/manager_stack.py
@@ -1,38 +1,20 @@
 import logging
-from typing import Dict, Optional
+from typing import TypeVar
 
-from golem.managers import (
-    ActivityManager,
-    AgreementManager,
-    DemandManager,
-    ProposalManager,
-    ProposalManagerPlugin,
-    ProposalScorer,
-)
-from pydantic import BaseModel, Field
+from golem.managers import Manager
+
+TManager = TypeVar("TManager", bound=Manager)
 
 logger = logging.getLogger(__name__)
 
 
-class ManagerStack(BaseModel):
-    demand_manager: Optional[DemandManager]
-    proposal_manager: Optional[ProposalManager]
-    agreement_manager: Optional[AgreementManager]
-    activity_manager: Optional[ActivityManager]
-    extra_proposal_plugins: Dict[str, ProposalManagerPlugin] = Field(default_factory=dict)
-    extra_proposal_scorers: Dict[str, ProposalScorer] = Field(default_factory=dict)
+class ManagerStack:
+    def __init__(self) -> None:
+        self._managers = []
 
-    class Config:
-        arbitrary_types_allowed = True
-
-    @property
-    def _managers(self):
-        return [
-            self.demand_manager,
-            self.proposal_manager,
-            self.agreement_manager,
-            self.activity_manager,
-        ]
+    def add_manager(self, manager: TManager) -> TManager:
+        self._managers.append(manager)
+        return manager
 
     async def start(self) -> None:
         logger.info("Starting stack managers...")

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -317,7 +317,8 @@ class RayService:
 
             raise NodeNotFound
 
-    def _is_head_node(self, tags: Tags) -> bool:
+    @staticmethod
+    def _is_head_node(tags: Tags) -> bool:
         return tags.get(TAG_RAY_NODE_KIND) == NODE_KIND_HEAD
 
     def _print_ssh_command(

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from golem.utils.asyncio import create_task_with_logging, ensure_cancelled_many
 from golem.utils.logging import get_trace_id_name
-from ray.autoscaler.tags import NODE_KIND_HEAD, TAG_RAY_NODE_KIND
+from ray.autoscaler.tags import NODE_KIND_HEAD, TAG_RAY_NODE_KIND, TAG_RAY_USER_NODE_TYPE
 
 from ray_on_golem.exceptions import RayOnGolemError
 from ray_on_golem.server.exceptions import NodeNotFound
@@ -147,6 +147,7 @@ class RayService:
                         self._create_node(
                             node_id,
                             NodeConfigData(**node_config),
+                            node_type=self._get_node_type(tags),
                             is_head_node=self._is_head_node(tags),
                         ),
                         trace_id=get_trace_id_name(self, f"create-node-{node_id}"),
@@ -159,7 +160,7 @@ class RayService:
         return created_node_ids
 
     async def _create_node(
-        self, node_id: NodeId, node_config: NodeConfigData, is_head_node: bool
+        self, node_id: NodeId, node_config: NodeConfigData, node_type: str, is_head_node: bool
     ) -> None:
         logger.info("Creating node `%s`...", node_id)
 
@@ -172,6 +173,7 @@ class RayService:
                 total_budget=self._provider_config.total_budget,
                 payment_network=self._provider_config.payment_network,
                 add_state_log=partial(self._add_node_state_log, node_id),
+                node_type=node_type,
                 is_head_node=is_head_node,
             )
 
@@ -320,6 +322,10 @@ class RayService:
     @staticmethod
     def _is_head_node(tags: Tags) -> bool:
         return tags.get(TAG_RAY_NODE_KIND) == NODE_KIND_HEAD
+
+    @staticmethod
+    def _get_node_type(tags: Tags) -> str:
+        return tags.get(TAG_RAY_USER_NODE_TYPE)
 
     def _print_ssh_command(
         self, ip: str, ssh_proxy_command: str, ssh_user: str, ssh_private_key_path: Path

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -50,8 +50,6 @@ PAYMENT_NETWORK_POLYGON = "polygon"
 PAYMENT_NETWORK_GOERLI = "goerli"
 PAYMENT_DRIVER_ERC20 = "erc20"
 
-SUGGESTED_HEADS_SUBNET_TAG = "ray-on-golem-heads"
-
 RAY_ON_GOLEM_PATH = Path(os.getenv("RAY_ON_GOLEM_PATH", "ray-on-golem"))
 YAGNA_PATH = Path(os.getenv("YAGNA_PATH", "yagna"))
 WEBSOCAT_PATH = Path(os.getenv("WEBSOCAT_PATH", "websocat"))

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -50,6 +50,8 @@ PAYMENT_NETWORK_POLYGON = "polygon"
 PAYMENT_NETWORK_GOERLI = "goerli"
 PAYMENT_DRIVER_ERC20 = "erc20"
 
+SUGGESTED_HEADS_SUBNET_TAG = "ray-on-golem-heads"
+
 RAY_ON_GOLEM_PATH = Path(os.getenv("RAY_ON_GOLEM_PATH", "ray-on-golem"))
 YAGNA_PATH = Path(os.getenv("YAGNA_PATH", "yagna"))
 WEBSOCAT_PATH = Path(os.getenv("WEBSOCAT_PATH", "websocat"))

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -30,7 +30,6 @@ RAY_ON_GOLEM_STOP_TIMEOUT = timedelta(minutes=3)
 
 RAY_ON_GOLEM_PID_FILENAME = "ray_on_golem.pid"
 
-
 URL_STATUS = "/"
 URL_CREATE_CLUSTER = "/create_cluster"
 URL_NON_TERMINATED_NODES = "/non_terminated_nodes"


### PR DESCRIPTION
What I've done:
- Introduced a new demand manager for combining other demand managers (**I'm open to better names**)
- Made that in case of head node request, suggested nodes will be added to demands and scored better
- Network stats will use suggested nodes too, as it can impact the number of providers
- Removed explicit fields from ManagerStack in favor of just a collection to start/stop children in order, proving that Manager Stack is a blind alley
- Small yaml cleanup, adding explicit head node pointer for the sake of network stats logic

Notable remarks:
- This PR should be checked with golem-core changes: https://github.com/golemfactory/golem-core-python/compare/main...approxit/suggested-heads
- Suggested heads right now are only available on the mainnet.
- As the ManagerStack is still considered as a draft, it proved that it can only solve the start/stop problem, and can't solve the problem of how to access its children / partial definitions. `stack._managers[-1]` is a way with no exit. Another SDK API concept with stages should solve this issue.