### PR TITLE
Stability fixes

### DIFF
--- a/golem-cluster.yaml
+++ b/golem-cluster.yaml
@@ -10,7 +10,7 @@ cluster_name: golem-cluster
 max_workers: 10
 
 # The number of minutes that need to pass before an idle worker node is removed by the Autoscaler
-#idle_timeout_minutes: 2
+idle_timeout_minutes: 5
 
 # The cloud provider-specific configuration properties.
 provider:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ packages = [{include = "ray_on_golem"}]
 [tool.poetry.dependencies]
 python = "^3.8.1"
 
-ray = {version="~2.9.3", extras=["default"]}
-#golem-core = {path="../golem-core-python", develop=true}
-#golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="main"}
-golem-core = "^0.6.2"
+ray = {version = "~2.9.3", extras = ["default"]}
+#golem-core = {path = "../golem-core-python", develop = true}
+golem-core = {git = "https://github.com/golemfactory/golem-core-python.git", branch = "main"}
+#golem-core = "^0.6.2"
 aiohttp = "^3"
 requests = "^2"
 click = "^8"
@@ -35,10 +35,10 @@ setuptools = "*"
 [tool.poetry.group.ray.dependencies]
 python = "^3.8.1"
 
-ray = {version="==2.9.3", extras=["default"]}
-#golem-core = {path="../golem-core-python", develop=true}
-#golem-core = {git="https://github.com/golemfactory/golem-core-python.git", branch="main"}
-golem-core = "^0.6.2"
+ray = {version = "==2.9.3", extras = ["default"]}
+#golem-core = {path = "../golem-core-python", develop = true}
+golem-core = {git = "https://github.com/golemfactory/golem-core-python.git", branch = "main"}
+#golem-core = "^0.6.2"
 aiohttp = "^3"
 requests = "^2"
 click = "^8"

--- a/ray_on_golem/network_stats/services/network_stats.py
+++ b/ray_on_golem/network_stats/services/network_stats.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from typing import Dict, Optional, Sequence
 
 from golem.managers import (
-    DefaultPaymentManager,
     DefaultProposalManager,
     NegotiatingPlugin,
     PaymentPlatformNegotiator,
@@ -27,7 +26,10 @@ from ya_market import ApiException
 
 from ray_on_golem.reputation.plugins import ProviderBlacklistPlugin
 from ray_on_golem.server.models import NodeConfigData
-from ray_on_golem.server.services.golem.golem import DEFAULT_DEMAND_LIFETIME
+from ray_on_golem.server.services.golem.golem import (
+    DEFAULT_DEMAND_LIFETIME,
+    DeviceListAllocationPaymentManager,
+)
 from ray_on_golem.server.services.golem.helpers.demand_config import DemandConfigHelper
 from ray_on_golem.server.services.golem.helpers.manager_stack import ManagerStackNodeConfigHelper
 from ray_on_golem.server.services.golem.manager_stack import ManagerStack
@@ -129,7 +131,7 @@ class NetworkStatsService:
 
         self._payment_manager: Optional[PaymentManager] = None
 
-    async def init(self, yagna_appkey: str) -> None:
+    async def start(self, yagna_appkey: str) -> None:
         logger.info("Starting NetworkStatsService...")
 
         self._golem = GolemNode(app_key=yagna_appkey)
@@ -138,7 +140,7 @@ class NetworkStatsService:
 
         logger.info("Starting NetworkStatsService done")
 
-    async def shutdown(self) -> None:
+    async def stop(self) -> None:
         logger.info("Stopping NetworkStatsService...")
 
         await self._golem.aclose()
@@ -170,16 +172,15 @@ class NetworkStatsService:
                 duration_minutes, node_type, " (head node)" if is_head_node else ""
             )
         )
-        consume_proposals_task = asyncio.create_task(self._consume_draft_proposals(stack))
+
         try:
-            await asyncio.wait(
-                [consume_proposals_task],
+            await asyncio.wait_for(
+                self._consume_draft_proposals(stack),
                 timeout=timedelta(minutes=duration_minutes).total_seconds(),
             )
+        except asyncio.TimeoutError:
+            pass
         finally:
-            consume_proposals_task.cancel()
-            await consume_proposals_task
-
             await stack.stop()
             await self._payment_manager.stop()
             self._payment_manager = None
@@ -192,8 +193,6 @@ class NetworkStatsService:
             while True:
                 draft = await stack._managers[-1].get_draft_proposal()
                 drafts.append(draft)
-        except asyncio.CancelledError:
-            return
         finally:
             await asyncio.gather(
                 # FIXME better reason message
@@ -210,7 +209,7 @@ class NetworkStatsService:
         is_head_node: bool,
     ) -> ManagerStack:
         if not self._payment_manager:
-            self._payment_manager = DefaultPaymentManager(
+            self._payment_manager = DeviceListAllocationPaymentManager(
                 self._golem, budget=total_budget, network=payment_network, driver=payment_driver
             )
             await self._payment_manager.start()
@@ -228,6 +227,9 @@ class NetworkStatsService:
         )
         ManagerStackNodeConfigHelper.apply_budget_control_hard_limits(
             extra_proposal_plugins, node_config
+        )
+        ManagerStackNodeConfigHelper.apply_priority_head_node_scoring(
+            extra_proposal_scorers, node_config
         )
 
         demand_manager = ManagerStackNodeConfigHelper.prepare_demand_manager_for_node_type(

--- a/ray_on_golem/server/main.py
+++ b/ray_on_golem/server/main.py
@@ -138,11 +138,11 @@ async def shutdown_print(app: web.Application) -> None:
 async def yagna_service_ctx(app: web.Application) -> None:
     yagna_service: YagnaService = app["yagna_service"]
 
-    await yagna_service.init()
+    await yagna_service.start()
 
     yield
 
-    await yagna_service.shutdown()
+    await yagna_service.stop()
 
 
 async def golem_service_ctx(app: web.Application) -> None:

--- a/ray_on_golem/server/services/golem/golem.py
+++ b/ray_on_golem/server/services/golem/golem.py
@@ -64,8 +64,7 @@ class DeviceListAllocationPaymentManager(DefaultPaymentManager):
     @trace_span(show_arguments=True, show_results=True)
     async def _create_allocation(self, budget: Decimal, network: str, driver: str) -> Allocation:
         output = json.loads(
-            # await run_subprocess_output(YAGNA_PATH, "payment", "driver", "list", "--json")  # yagna 0.15+
-            await run_subprocess_output(YAGNA_PATH, "payment", "drivers", "--json")  # yagna 0.13
+            await run_subprocess_output(YAGNA_PATH, "payment", "driver", "list", "--json")
         )
 
         try:
@@ -82,9 +81,9 @@ class DeviceListAllocationPaymentManager(DefaultPaymentManager):
             total_amount=str(budget),
             timestamp=timestamp,
             timeout=timeout,
-            #   This will probably be removed one day (consent-related thing)
+            # This will probably be removed one day (consent-related thing)
             make_deposit=False,
-            #   We must set this here because of the ya_client interface
+            # We must set this here because of the ya_client interface
             allocation_id="",
             spent_amount="",
             remaining_amount="",

--- a/ray_on_golem/server/services/golem/helpers/manager_stack.py
+++ b/ray_on_golem/server/services/golem/helpers/manager_stack.py
@@ -24,6 +24,8 @@ from ray_on_golem.server.services.golem.manager_stack import ManagerStack
 
 logger = logging.getLogger(__name__)
 
+HEAD_NODE_EXTRA_SCORE = 100
+
 
 class ManagerStackNodeConfigHelper:
     @staticmethod
@@ -118,7 +120,7 @@ class ManagerStackNodeConfigHelper:
             proposal_data.properties.get("golem.node.debug.subnet") == priority_head_subnet_tag
         )
 
-        return 100.0 if add_scoring else 0.0
+        return HEAD_NODE_EXTRA_SCORE if add_scoring else 0
 
     @staticmethod
     def prepare_demand_manager_for_node_type(

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -107,7 +107,7 @@ class RayService:
         with self._ssh_public_key_path.open() as f:
             self._ssh_public_key = f.readline().strip()
 
-        payment_status = await self._yagna_service.run_payment_fund(
+        payment_status = await self._yagna_service.prepare_funds(
             self._provider_config.payment_network,
             self._provider_config.payment_driver,
         )


### PR DESCRIPTION
Requires https://github.com/golemfactory/golem-core-python/pull/147 to be merged.

What I've done:
- Pulled down yagna version to `0.13.3`, as allocation creation is version-sensitive
- Reworked main loop of network stats, as [#181](https://github.com/golemfactory/ray-on-golem/pull/181/files#diff-f60d4e72ce0a6202fc54ed72f75b6d4f878f99436f8797771338e8ca27a6a0bcR167-R168) exposed problem with graceful shutdown while using `asyncio.run`
- Changed flow with `_consume_draft_proposals` to use `asyncio.wait_for` instead of `asyncio.wait`, as in this way we don't need to handle its cancellation manually
- Introduced `DeviceListAllocationPayMentManager` which has allocation creation based on payment devices, instead of account lists - this change is a step towards yagna 0.15 support. Note that placement is not random, as yagna 0.15+ does not have API endpoint to fetch the device list, and it must be done at CLI level, which is used only on ray-on-golem, and not in api-centric golem-core
- Added suggested heads extra scoring to network stats
- Made proposal concurrency smaller, to not overshoot the currently available amount of suggested heads on the mainnet
- Made proposal expiration time smaller, to avoid generating warnings about too-late expiration
- Made suggested heads score boost bigger to keep them at the top of the proposal scoring
- Added `--sender` argument in case of mainnet fund preparation

Notable remarks:
- While executing `asyncio.run(func())`, `KeyboardInterrupt` can be raised in a random place (it could be somewhere in `func` or somewhere in event loop internals), stopping `func` execution. `asyncio.run` will catch that exception and will try to cancel **all remaining** tasks at once. In this way, we can't control the order of graceful shutdown. This should work in [python 3.11+](https://docs.python.org/3.12/library/asyncio-runner.html#handling-keyboard-interruption), but we are stuck in python 3.8.
- Yagna 0.15+ have reworked payment flow, where accounts are automatically prepared when needed, so `yagna payments init --sender --network polygon` is not needed at all.