### PR TITLE
Ssh timings

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -6,7 +6,7 @@ on:
       BRANCH:
         type: string
         description: Git branch to be used in run
-        default: main
+        default: ${{ github.ref }}
 
 jobs:
   examples:
@@ -93,11 +93,17 @@ jobs:
       - name: Stop Goth
         run: ./.github/workflows/stop-goth.sh
 
+      - name: Prepare artifact name
+        run: |
+          branch_name = ${{ inputs.BRANCH }}
+          branch_name = ${branch_name//\//_}
+          echo ARTIFACT_NAME=logs-example-${branch_name}-${{ matrix.example_name }} >> $GITHUB_ENV
+
       - name: Collects logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: logs-example-${{ inputs.BRANCH }}-${{ matrix.example_name }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: |
             /root/.local/share/ray_on_golem/webserver_debug.log
             /root/.local/share/ray_on_golem/yagna.log

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -44,9 +44,14 @@ jobs:
         with:
           ref: ${{ inputs.BRANCH }}
 
+      - name: Clean up previous runs
+        run: |
+          pkill -f ray-on-golem || true
+          pkill -f goth || true
+
       - name: Start Goth
         env:
-          GOTH_VERSION: 0.15.11
+          GOTH_VERSION: 0.16.0
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: ./.github/workflows/start-goth.sh
@@ -59,9 +64,7 @@ jobs:
 
       - name: Prepare `golem-cluster.tests.yaml`
         run: |
-          cat /etc/hosts
-          cat /etc/hostname
-          poetry run python -m utils.apply_overrides -b ${{ matrix.base_yaml_path || './golem-cluster.yaml' }} -o golem-cluster.tests.yaml golem-cluster.override.2-image.yaml golem-cluster.override.3-disable-stats.yaml golem-cluster.override-goth.yaml
+          poetry run python -m utils.apply_overrides -b ${{ matrix.base_yaml_path || './golem-cluster.yaml' }} golem-cluster.override.2-image.yaml golem-cluster.override.3-disable-stats.yaml golem-cluster.override-goth.yaml -o golem-cluster.tests.yaml
           cat golem-cluster.tests.yaml 
 
       - name: Call `ray up`
@@ -76,6 +79,7 @@ jobs:
       - name: Print last cluster logs
         if: always()
         continue-on-error: true
+        timeout-minutes: 1
         run: |
           poetry run ray exec golem-cluster.tests.yaml 'ls /tmp/ray/session_latest/logs/'
           poetry run ray exec golem-cluster.tests.yaml 'tail -n 100 /tmp/ray/session_latest/logs/*'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -6,7 +6,7 @@ on:
       BRANCH:
         type: string
         description: Git branch to be used in run
-        default: ${{ github.ref }}
+        default: ${{ github.head_ref }}
 
 jobs:
   examples:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -95,9 +95,7 @@ jobs:
 
       - name: Prepare artifact name
         run: |
-          branch_name = ${{ inputs.BRANCH }}
-          branch_name = ${branch_name//\//_}
-          echo ARTIFACT_NAME=logs-example-${branch_name}-${{ matrix.example_name }} >> $GITHUB_ENV
+          echo ARTIFACT_NAME=logs-example-${${{ inputs.BRANCH }}//\//_}-${{ matrix.example_name }} >> $GITHUB_ENV
 
       - name: Collects logs
         if: always()

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Prepare artifact name
         run: |
-          echo ARTIFACT_NAME=logs-example-${${{ inputs.BRANCH }}//\//_}-${{ matrix.example_name }} >> $GITHUB_ENV
+          echo ARTIFACT_NAME=logs-example-${{ inputs.BRANCH }}-${{ matrix.example_name }} | sed "s|/|_|g" >> $GITHUB_ENV
 
       - name: Collects logs
         if: always()

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -11,10 +11,9 @@ jobs:
   code_tests:
     name: Code checks
     uses: ./.github/workflows/code_tests.yml
-# FIXME: Enable integration tests when they became stable
-#  integration_tests:
-#    name: Integration tests
-#    uses: ./.github/workflows/integration_tests.yml
+  integration_tests:
+    name: Integration tests
+    uses: ./.github/workflows/integration_tests.yml
   smoke_tests:
     name: Smoke tests
     uses: ./.github/workflows/smoke_tests.yml

--- a/.github/workflows/on_schedule.yml
+++ b/.github/workflows/on_schedule.yml
@@ -3,7 +3,7 @@ name: On schedule
 on:
   schedule:
     # run this workflow every day at 2:00 AM UTC
-    -   cron: '0 2 * * *'
+    - cron: '0 2 * * *'
 
 jobs:
   nightly_tests:

--- a/.github/workflows/start-goth.sh
+++ b/.github/workflows/start-goth.sh
@@ -13,6 +13,7 @@ rm -rf /tmp/goth-tests/
 
 echo CREATING VENV
 rm -rf .envs/goth
+sudo apt-get install python3.10-venv -y
 python -m venv .envs/goth
 source .envs/goth/bin/activate
 
@@ -21,16 +22,17 @@ python -m pip install --upgrade pip
 python -m pip install --upgrade setuptools wheel
 
 echo INSTALLING DEPENDENCIES
-python -m pip install goth==$GOTH_VERSION pytest pytest-asyncio pexpect
+python -m pip install --extra-index-url https://test.pypi.org/simple/ goth==$GOTH_VERSION
+python -m pip install pytest pytest-asyncio pexpect
 
 echo CREATING ASSETS
 python -m goth create-assets .envs/goth/assets
 # disable use-proxy
-sed -Ezi 's/("\n.*use\-proxy:\s)(True)/\1False/mg' .envs/goth/assets/goth-config.yml
+sed -Ezi 's/("\n.*use\-proxy:\s)(True)/\1False/mg' .envs/goth/assets/goth-config-testing.yml
 
 echo STARTING NETWORK
-cat .envs/goth/assets/goth-config.yml
-python -m goth start .envs/goth/assets/goth-config.yml &
+cat .envs/goth/assets/goth-config-testing.yml
+python -m goth start .envs/goth/assets/goth-config-testing.yml &
 GOTH_PID=$!
 echo "GOTH_PID=$GOTH_PID" | tee -a "$GITHUB_ENV"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get update && apt-get install -y \
 
 RUN echo "UseDNS no" >> /etc/ssh/sshd_config && \
 	echo "PermitRootLogin yes" >> /etc/ssh/sshd_config && \
-	echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
+	echo "PasswordAuthentication no" >> /etc/ssh/sshd_config && \
+	echo "ClientAliveInterval 60" >> /etc/ssh/sshd_config && \
+	echo "ClientAliveCountMax 3" >> /etc/ssh/sshd_config
 
 RUN pip install -U pip
 

--- a/golem-cluster.override-goth.yaml
+++ b/golem-cluster.override-goth.yaml
@@ -3,3 +3,6 @@ provider:
     node_config:
       subnet_tag: "goth"
       priority_head_subnet_tag: "goth"
+
+      demand:
+        outbound_urls: []

--- a/golem-cluster.override.2-image.yaml
+++ b/golem-cluster.override.2-image.yaml
@@ -2,4 +2,4 @@ provider:
   parameters:
     node_config:
       demand:
-        image_tag: "blueshade/ray-on-golem:0.10.0-dev-240402-1-py3.10.13-ray2.9.3"
+        image_tag: "approxit/ray-on-golem:ssh-timings"

--- a/golem-cluster.yaml
+++ b/golem-cluster.yaml
@@ -33,7 +33,7 @@ provider:
       # Parameters for golem demands (same for head and workers)
       demand:
         # Check available versions at https://registry.golem.network/explore/golem/ray-on-golem
-        image_tag: "blueshade/ray-on-golem:0.10.0-dev-240402-1-py3.10.13-ray2.9.3"
+        image_tag: "approxit/ray-on-golem:ssh-timings"
 
         # List of urls which will be added to the Computation Manifest
         # Requires protocol to be defined in all URLs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ dev_yaml = {cmd = "python -m utils.apply_overrides -o golem-cluster.dev.yaml gol
 profile = "black"
 py_version = 38
 line_length = 100
+skip_gitignore = true
 
 [tool.autoflake]
 recursive = true

--- a/ray_on_golem/provider/ssh_command_runner.py
+++ b/ray_on_golem/provider/ssh_command_runner.py
@@ -2,6 +2,7 @@ from ray.autoscaler._private.command_runner import SSHCommandRunner as BaseSshCo
 from ray.autoscaler._private.command_runner import SSHOptions
 
 from ray_on_golem.server.services.utils import get_ssh_command
+from ray_on_golem.server.settings import SSH_SERVER_ALIVE_COUNT_MAX, SSH_SERVER_ALIVE_INTERVAL
 
 
 class SSHCommandRunner(BaseSshCommandRunner):
@@ -12,8 +13,8 @@ class SSHCommandRunner(BaseSshCommandRunner):
             self.ssh_private_key,
             self.ssh_control_path,
             ProxyCommand=self.ssh_proxy_command,
-            ServerAliveInterval=300,
-            ServerAliveCountMax=5,
+            ServerAliveInterval=SSH_SERVER_ALIVE_INTERVAL,
+            ServerAliveCountMax=SSH_SERVER_ALIVE_COUNT_MAX,
         )
 
     def remote_shell_command_str(self):

--- a/ray_on_golem/provider/ssh_command_runner.py
+++ b/ray_on_golem/provider/ssh_command_runner.py
@@ -1,9 +1,20 @@
-from ray.autoscaler._private.command_runner import SSHCommandRunner as BaseSshCommandRunner
+from ray.autoscaler._private.command_runner import SSHCommandRunner as BaseSshCommandRunner, SSHOptions
 
 from ray_on_golem.server.services.utils import get_ssh_command
 
 
 class SSHCommandRunner(BaseSshCommandRunner):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.ssh_options = SSHOptions(
+            self.ssh_private_key,
+            self.ssh_control_path,
+            ProxyCommand=self.ssh_proxy_command,
+            ServerAliveInterval=300,
+            ServerAliveCountMax=5,
+        )
+
     def remote_shell_command_str(self):
         return get_ssh_command(
             ip=self.ssh_ip,

--- a/ray_on_golem/provider/ssh_command_runner.py
+++ b/ray_on_golem/provider/ssh_command_runner.py
@@ -1,4 +1,5 @@
-from ray.autoscaler._private.command_runner import SSHCommandRunner as BaseSshCommandRunner, SSHOptions
+from ray.autoscaler._private.command_runner import SSHCommandRunner as BaseSshCommandRunner
+from ray.autoscaler._private.command_runner import SSHOptions
 
 from ray_on_golem.server.services.utils import get_ssh_command
 

--- a/ray_on_golem/server/services/utils.py
+++ b/ray_on_golem/server/services/utils.py
@@ -14,6 +14,8 @@ def get_ssh_command(
             "-o StrictHostKeyChecking=no",
             "-o UserKnownHostsFile=/dev/null",
             "-o PasswordAuthentication=no",
+            "-o ServerAliveInterval=300",
+            "-o ServerAliveCountMax=5",
             f"-o {quote(proxy_command_str)}",
             f"-i {quote(str(ssh_private_key_path))}" if ssh_private_key_path else "",
             quote(ssh_user_str),

--- a/ray_on_golem/server/services/utils.py
+++ b/ray_on_golem/server/services/utils.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from shlex import quote
 
+from ray_on_golem.server.settings import SSH_SERVER_ALIVE_COUNT_MAX, SSH_SERVER_ALIVE_INTERVAL
+
 
 def get_ssh_command(
     ip: str, ssh_proxy_command: str, ssh_user: str, ssh_private_key_path: Path
@@ -14,8 +16,8 @@ def get_ssh_command(
             "-o StrictHostKeyChecking=no",
             "-o UserKnownHostsFile=/dev/null",
             "-o PasswordAuthentication=no",
-            "-o ServerAliveInterval=300",
-            "-o ServerAliveCountMax=5",
+            f"-o ServerAliveInterval={SSH_SERVER_ALIVE_INTERVAL}",
+            f"-o ServerAliveCountMax={SSH_SERVER_ALIVE_COUNT_MAX}",
             f"-o {quote(proxy_command_str)}",
             f"-i {quote(str(ssh_private_key_path))}" if ssh_private_key_path else "",
             quote(ssh_user_str),

--- a/ray_on_golem/server/settings.py
+++ b/ray_on_golem/server/settings.py
@@ -33,6 +33,9 @@ RAY_ON_GOLEM_STOP_TIMEOUT = timedelta(minutes=3)
 
 RAY_ON_GOLEM_PID_FILENAME = "ray_on_golem.pid"
 
+SSH_SERVER_ALIVE_INTERVAL = 300
+SSH_SERVER_ALIVE_COUNT_MAX = 3
+
 URL_STATUS = "/"
 URL_BOOTSTRAP_CLUSTER = "/bootstrap_cluster"
 URL_NON_TERMINATED_NODES = "/non_terminated_nodes"

--- a/ray_on_golem/server/views.py
+++ b/ray_on_golem/server/views.py
@@ -4,10 +4,10 @@ import logging
 from aiohttp import web
 from pydantic import BaseModel
 
+from ray_on_golem.exceptions import RayOnGolemError
 from ray_on_golem.server import models, settings
 from ray_on_golem.server.models import ShutdownState
 from ray_on_golem.server.services import RayService
-from ray_on_golem.server.services.ray import RayServiceError
 from ray_on_golem.utils import raise_graceful_exit
 from ray_on_golem.version import get_version
 
@@ -59,7 +59,7 @@ async def bootstrap_cluster(request: web.Request) -> web.Response:
         ) = await ray_service.create_cluster(
             request_data.provider_config, request_data.cluster_name
         )
-    except RayServiceError as e:
+    except RayOnGolemError as e:
         raise web.HTTPBadRequest(reason=str(e))
 
     return json_response(

--- a/utils/yaml.py
+++ b/utils/yaml.py
@@ -24,6 +24,7 @@ def load_yamls(*yaml_paths: Path) -> Dict[str, Any]:
         dpath.merge(
             base_dict,
             data,
+            flags=dpath.MergeType.REPLACE,
         )
 
     return base_dict


### PR DESCRIPTION
What I've done:
- Added `ServerAliveInterval` and `ServerAliveCountMax` both for node provider's command runner and ssh commands
- Added `ClientAliveInterval` and `ClientAliveCountMax` in sshd_config to reflect similar keep alive (it is suggested to keep them lower than `Server*` counterparts).  
- Enabled integration tests on pull requests (yay!)
- Fixed problem, where YagnaService exceptions would be not caught properly at cluster bootstrap
- Changed emerging strategy in `dev_yaml` tool, to be able to remove outbound URLs for goth tests (currently outbound is not supported on goth)
- Bumped goth to 0.16.0 to support holesky and yagna in beta versions
- Uploaded new image version

Notable highlights:
- GCS / SSH commands problems are related to GolemNodeProvider being locked at `__init__`, while bootstrapping cluster and running `yagna fund` that in some cases are not working. This will be addressed shortly.