### PR TITLE
GCS port exposure

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -64,25 +64,39 @@ jobs:
 
       - name: Prepare `golem-cluster.tests.yaml`
         run: |
-          poetry run python -m utils.apply_overrides -b ${{ matrix.base_yaml_path || './golem-cluster.yaml' }} golem-cluster.override.2-image.yaml golem-cluster.override.3-disable-stats.yaml golem-cluster.override-goth.yaml -o golem-cluster.tests.yaml
-          cat golem-cluster.tests.yaml 
+          poetry run python -m utils.apply_overrides -b ${{ matrix.base_yaml_path || './golem-cluster.yaml' }} golem-cluster.override.1-source-files.yaml golem-cluster.override.2-image.yaml golem-cluster.override.3-disable-stats.yaml golem-cluster.override-goth.yaml -o golem-cluster.tests.yaml
+          cat golem-cluster.tests.yaml
+          free -h
+          ps -Heo size,command --sort -size
 
       - name: Call `ray up`
         env:
           PYTHONUNBUFFERED: 1
           RUST_LOG: "INFO,ya_erc20_driver::erc20::wallet=debug"
+        timeout-minutes: 5
         run: poetry run ray up golem-cluster.tests.yaml -y --no-config-cache
 
       - name: Run `examples/${{ matrix.example_name }}.py`
-        run: poetry run ray submit golem-cluster.tests.yaml examples/${{ matrix.example_name }}.py -- ${{ matrix.args }}
+        timeout-minutes: 5
+        run: |
+          poetry run ray exec golem-cluster.tests.yaml 'free -h'
+          poetry run ray exec golem-cluster.tests.yaml 'ps -Heo size,command --sort -size'
+          echo "= = = = BEFORE = = = ="
+          poetry run ray submit golem-cluster.tests.yaml examples/${{ matrix.example_name }}.py -- ${{ matrix.args }}
+          echo "= = = = AFTER = = = ="
+          poetry run ray exec golem-cluster.tests.yaml 'free -h'
+          poetry run ray exec golem-cluster.tests.yaml 'ps -Heo size,command --sort -size'
 
-      - name: Print last cluster logs
+      - name: Collect cluster logs
         if: always()
         continue-on-error: true
-        timeout-minutes: 1
+        timeout-minutes: 2
         run: |
-          poetry run ray exec golem-cluster.tests.yaml 'ls /tmp/ray/session_latest/logs/'
-          poetry run ray exec golem-cluster.tests.yaml 'tail -n 100 /tmp/ray/session_latest/logs/*'
+          poetry run ray exec golem-cluster.tests.yaml 'free -h'
+          poetry run ray exec golem-cluster.tests.yaml 'ps -Heo size,command --sort -size'
+          poetry run ray rsync-down golem-cluster.tests.yaml /root/mem_usage.log mem_usage.log
+          poetry run ray exec golem-cluster.tests.yaml 'ray cluster-dump --local --debug-state --processes-verbose -o ray_cluster_dump.tar.gz'
+          poetry run ray rsync-down golem-cluster.tests.yaml ray_cluster_dump.tar.gz ray_cluster_dump.tar.gz
 
       - name: Call `ray down`
         run: poetry run ray down golem-cluster.tests.yaml -y
@@ -90,7 +104,11 @@ jobs:
       - name: Call `ray-on-golem stop`
         run: poetry run ray-on-golem stop
 
+      - name: Check node creation in logs
+        run: poetry run python tests/webserver_logs_test.py ~/.local/share/ray_on_golem/webserver.log 2
+
       - name: Stop Goth
+        if: always()
         run: ./.github/workflows/stop-goth.sh
 
       - name: Prepare artifact name
@@ -107,3 +125,5 @@ jobs:
             /root/.local/share/ray_on_golem/webserver_debug.log
             /root/.local/share/ray_on_golem/yagna.log
             /tmp/goth-tests
+            ray_cluster_dump.tar.gz
+            mem_usage.log

--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -25,8 +25,10 @@ jobs:
         run: poetry install --no-ansi
 
       - name: Prepare `golem-cluster.tests.yaml`
+        run: |
+          poetry run python -m utils.apply_overrides -o golem-cluster.tests.yaml golem-cluster.override.1-source-files.yaml golem-cluster.override.2-image.yaml golem-cluster.override.3-disable-stats.yaml golem-cluster.override.4-subnet.yaml
+          cat golem-cluster.tests.yaml
 
-        run: poetry run python -m utils.apply_overrides -o golem-cluster.tests.yaml golem-cluster.override.2-image.yaml golem-cluster.override.3-disable-stats.yaml golem-cluster.override.4-subnet.yaml
       - name: Call `ray up`
         env:
           PYTHONUNBUFFERED: 1
@@ -43,8 +45,7 @@ jobs:
         run: poetry run ray-on-golem stop
 
       - name: Check node creation in logs
-        continue-on-error: true
-        run: poetry run python tests/smoke.py ~/.local/share/ray_on_golem/webserver_debug.log
+        run: poetry run python tests/webserver_logs_test.py ~/.local/share/ray_on_golem/webserver.log 2
 
       - name: Collects logs
         if: always()

--- a/.github/workflows/start-goth.sh
+++ b/.github/workflows/start-goth.sh
@@ -29,9 +29,11 @@ echo CREATING ASSETS
 python -m goth create-assets .envs/goth/assets
 # disable use-proxy
 sed -Ezi 's/("\n.*use\-proxy:\s)(True)/\1False/mg' .envs/goth/assets/goth-config-testing.yml
+sed -Ezi 's/("mem_gib":\s+)(1.0)/\11.5/mg' .envs/goth/assets/provider/hardware.json
 
 echo STARTING NETWORK
 cat .envs/goth/assets/goth-config-testing.yml
+cat .envs/goth/assets/provider/hardware.json
 python -m goth start .envs/goth/assets/goth-config-testing.yml &
 GOTH_PID=$!
 echo "GOTH_PID=$GOTH_PID" | tee -a "$GITHUB_ENV"

--- a/golem-cluster.full.yaml
+++ b/golem-cluster.full.yaml
@@ -22,6 +22,12 @@ provider:
     # Port of golem webserver that has connection with golem network
     webserver_port: 4578
 
+    # Ports under which Ray's GCS and dashboard will be exposed on the local machine
+    # Needs to be changed while running multiple clusters on a single machine
+    # Can be null to disable exposure
+    ray_gcs_expose_port: 6379
+    ray_dashboard_expose_port: 8265
+
     # Blockchain used for payments.
     # `holesky` means running free nodes on testnet,
     # `polygon` is for mainnet operations.

--- a/ray_on_golem/provider/node_provider.py
+++ b/ray_on_golem/provider/node_provider.py
@@ -40,6 +40,8 @@ ONBOARDING_MESSAGE = {
 PROVIDER_DEFAULTS = {
     "webserver_port": 4578,
     "webserver_datadir": None,
+    "ray_gcs_expose_port": 6379,
+    "ray_dashboard_expose_port": 8265,
     "enable_registry_stats": True,
     "payment_network": PAYMENT_NETWORK_HOLESKY,
     "payment_driver": PAYMENT_DRIVER_ERC20,

--- a/ray_on_golem/provider/ssh_command_runner.py
+++ b/ray_on_golem/provider/ssh_command_runner.py
@@ -40,6 +40,7 @@ class SSHCommandRunner(BaseSshCommandRunner):
         command += ["-avz"]
         command += ["--no-o"]
         command += ["--no-g"]
+        command += ["-v", "--stats", "--progress"]
         command += self._create_rsync_filter_args(options=options)
         command += [source, "{}@{}:{}".format(self.ssh_user, self.ssh_ip, target)]
         cli_logger.verbose("Running `{}`", cf.bold(" ".join(command)))
@@ -56,6 +57,7 @@ class SSHCommandRunner(BaseSshCommandRunner):
         command += ["-avz"]
         command += ["--no-o"]
         command += ["--no-g"]
+        command += ["-v", "--stats", "--progress"]
         command += self._create_rsync_filter_args(options=options)
         command += ["{}@{}:{}".format(self.ssh_user, self.ssh_ip, source), target]
         cli_logger.verbose("Running `{}`", cf.bold(" ".join(command)))

--- a/ray_on_golem/server/cluster/cluster.py
+++ b/ray_on_golem/server/cluster/cluster.py
@@ -188,6 +188,8 @@ class Cluster(WarningMessagesMixin):
             partial(
                 HeadClusterNode,
                 webserver_port=self._webserver_port,
+                ray_gcs_expose_port=self._provider_parameters.ray_gcs_expose_port,
+                ray_dashboard_expose_port=self._provider_parameters.ray_dashboard_expose_port,
             )
             if is_head_node
             else WorkerClusterNode

--- a/ray_on_golem/server/cluster/nodes.py
+++ b/ray_on_golem/server/cluster/nodes.py
@@ -463,14 +463,14 @@ class HeadClusterNode(WorkerClusterNode):
             PortTunnelClusterNodeSidecar(node=self, local_port=self._webserver_port, reverse=True),
         ]
 
-        if self._ray_gcs_expose_port is not None:
+        if self._ray_gcs_expose_port:
             sidecars.append(
                 PortTunnelClusterNodeSidecar(
                     node=self, local_port=self._ray_gcs_expose_port, remote_port=RAY_GCS_PORT
                 ),
             )
 
-        if self._ray_dashboard_expose_port is not None:
+        if self._ray_dashboard_expose_port:
             sidecars.append(
                 PortTunnelClusterNodeSidecar(
                     node=self,

--- a/ray_on_golem/server/cluster/nodes.py
+++ b/ray_on_golem/server/cluster/nodes.py
@@ -292,6 +292,7 @@ class ClusterNode(WarningMessagesMixin, NodeData):
         await self._run_command(
             context, f'echo "{ssh_public_key_data}" >> /root/.ssh/authorized_keys'
         )
+        await self._run_command(context, "watch 'free -h >> /root/mem_usage.log' &")
 
     async def _start_ssh_server(self, context: WorkContext, ip: str, provider_desc: str):
         logger.info(f"Starting ssh service on {provider_desc}, {ip=}, {context.activity=}")

--- a/ray_on_golem/server/cluster/sidecars.py
+++ b/ray_on_golem/server/cluster/sidecars.py
@@ -202,7 +202,7 @@ class PortTunnelClusterNodeSidecar(ClusterNodeSidecar):
         super().__init__(**kwargs)
 
         self._local_port = local_port
-        self._remote_port = local_port if remote_port is None else remote_port
+        self._remote_port = remote_port or local_port
         self._reverse = reverse
 
         self._tunnel_process: Optional[Process] = None

--- a/ray_on_golem/server/models.py
+++ b/ray_on_golem/server/models.py
@@ -89,6 +89,8 @@ class NodeConfigData(BaseModel):
 
 class ProviderParametersData(BaseModel):
     webserver_port: int
+    ray_gcs_expose_port: Optional[int]
+    ray_dashboard_expose_port: Optional[int]
     enable_registry_stats: bool
     payment_network: str
     payment_driver: str

--- a/ray_on_golem/server/services/__init__.py
+++ b/ray_on_golem/server/services/__init__.py
@@ -13,6 +13,7 @@ __all__ = (
     "DriverListAllocationPaymentManager",
     "GolemService",
     "ManagerStack",
+    "ManagerStackNodeConfigHelper",
     "get_manifest",
     "DemandConfigHelper",
     "RayService",

--- a/ray_on_golem/server/services/golem/golem.py
+++ b/ray_on_golem/server/services/golem/golem.py
@@ -104,4 +104,4 @@ class GolemService:
 
     def get_ssh_proxy_command(self, connection_uri: URL) -> str:
         # Using single quotes for the authentication token as double quotes are causing problems with CLI character escaping in ray
-        return f"{self._websocat_path} asyncstdio: {connection_uri}/22 --binary -H=Authorization:'Bearer {self._yagna_appkey}'"
+        return f"{self._websocat_path} -vv asyncstdio: {connection_uri}/22 --binary -H=Authorization:'Bearer {self._yagna_appkey}'"

--- a/ray_on_golem/utils.py
+++ b/ray_on_golem/utils.py
@@ -80,6 +80,7 @@ def get_ssh_command_args(
 ) -> List[str]:
     return [
         "ssh",
+        "-vvv",
         "-o",
         "StrictHostKeyChecking=no",
         "-o",

--- a/tests/webserver_logs_test.py
+++ b/tests/webserver_logs_test.py
@@ -1,10 +1,10 @@
 import re
 import sys
 
-creating_re = re.compile(r".*] Creating node `[^`]+`\.\.\..*")
-created_re = re.compile(r".*] Creating node `[^`]+` done.*")
-terminating_re = re.compile(r".*] Terminating node `[^`]+`\.\.\..*")
-terminated_re = re.compile(r".*] Terminating node `[^`]+` done.*")
+creating_re = re.compile(r"^.*] Starting `[^`]+` node\.\.\..*$")
+created_re = re.compile(r"^.*] Starting `[^`]+` node done.*$")
+terminating_re = re.compile(r"^.*] Stopping `[^`]+` node\.\.\..*$")
+terminated_re = re.compile(r"^.*] Stopping `[^`]+` node done.*$")
 
 creating_count = 0
 created_count = 0
@@ -30,29 +30,25 @@ with open(sys.argv[1]) as file:
             terminated_count += 1
 
 errors = []
-if creating_count != created_count:
-    errors.append(
-        f"Logs contains miss-matched logs at node creation level: started={creating_count} finished={created_count}"
-    )
-
 if terminating_count != terminated_count:
     errors.append(
         f"Logs contains miss-matched logs at node termination level: started={terminating_count} finished="
         f"{terminated_count}"
     )
 
-if created_count != terminated_count:
-    errors.append(
-        f"Logs contains miss-matched logs between node creation and termination level: created={created_count} "
-        f"terminated={terminated_count}"
-    )
+if creating_count != terminated_count:
+    errors.append(f"Logs contains miss-matched logs between node creating and termination level!")
 
 if not created_count:
-    errors.append("No creation entries found in log file!")
+    errors.append("No completed node creation entries found in log file!")
+
+min_creating = int(sys.argv[2])
+if creating_count < min_creating:
+    errors.append(f"Node creation is below `{min_creating}`")
+
+print(f"Nodes: {creating_count=} {created_count=} {terminating_count=} {terminated_count=}")
 
 if errors:
     print("Errors:", file=sys.stderr)
     print("\n".join(errors), file=sys.stderr)
     exit(1)
-else:
-    print(f"Nodes: created={created_count} terminated={terminated_count}")


### PR DESCRIPTION
What I've done:
- Added option to expose GCS ports to the local (requestor) machine.

Notable remarks:
- `ray status --address=localhost:6379` can check cluster state by using the exposed GCS port (which has binary payloads)
- `ray job submit --address http://localhost:8265 --working-dir . -- python calculate.py` can submit the job by using the `ray dashboard` command (which has http payloads)