### PR TITLE
Cluster cleanup

### DIFF
--- a/golem-cluster.full.yaml
+++ b/golem-cluster.full.yaml
@@ -5,7 +5,7 @@
 # Ray on Golem cluster name
 # This value identifies a given cluster within the ray-on-golem webserver.
 # Therefore, it must be unique if you ever wish to run more than one cluster on the same ray-on-golem instance.
-cluster_name: golem-cluster
+cluster_name: "golem-cluster"
 
 # The maximum number of workers the cluster will have at any given time
 max_workers: 10
@@ -22,11 +22,10 @@ provider:
     # Port of golem webserver that has connection with golem network
     webserver_port: 4578
 
-    # Ports under which Ray's GCS and dashboard will be exposed on the local machine
+    # Port under which Ray's GCS will be exposed on the local machine
     # Needs to be changed while running multiple clusters on a single machine
     # Can be null to disable exposure
     ray_gcs_expose_port: 6379
-    ray_dashboard_expose_port: 8265
 
     # Blockchain used for payments.
     # `holesky` means running free nodes on testnet,
@@ -111,7 +110,7 @@ available_node_types:
     node_config: {}
 
 # Specify the node type of the head node (as configured above).
-head_node_type: ray.head.default
+head_node_type: "ray.head.default"
 
 # The files or directories to copy to the head and worker nodes
 # Remote workdir is /root/
@@ -152,5 +151,5 @@ worker_start_ray_commands: [
 
 # Satisfy checks to disable warning about legacy fields at `ray up`.
 # This will be removed by ray-on-golem on the fly.
-head_node: True
-worker_nodes: True
+head_node: true
+worker_nodes: true

--- a/golem-cluster.mini.yaml
+++ b/golem-cluster.mini.yaml
@@ -2,7 +2,7 @@
 
 
 # Ray on Golem cluster name
-cluster_name: golem-cluster
+cluster_name: "golem-cluster"
 
 # The maximum number of workers the cluster will have at any given time
 max_workers: 10

--- a/golem-cluster.yaml
+++ b/golem-cluster.yaml
@@ -4,7 +4,7 @@
 # - with properties allowing fine-tuning
 
 # Ray on Golem cluster name
-cluster_name: golem-cluster
+cluster_name: "golem-cluster"
 
 # The maximum number of workers the cluster will have at any given time
 max_workers: 10
@@ -135,6 +135,6 @@ worker_start_ray_commands: [
 
 # Satisfy checks to disable warning about legacy fields at `ray up`.
 # This will be removed by ray-on-golem on the fly.
-head_node: True
-worker_nodes: True
+head_node: true
+worker_nodes: true
 

--- a/ray_on_golem/provider/node_provider.py
+++ b/ray_on_golem/provider/node_provider.py
@@ -41,7 +41,6 @@ PROVIDER_DEFAULTS = {
     "webserver_port": 4578,
     "webserver_datadir": None,
     "ray_gcs_expose_port": 6379,
-    "ray_dashboard_expose_port": 8265,
     "enable_registry_stats": True,
     "payment_network": PAYMENT_NETWORK_HOLESKY,
     "payment_driver": PAYMENT_DRIVER_ERC20,

--- a/ray_on_golem/server/cluster/cluster.py
+++ b/ray_on_golem/server/cluster/cluster.py
@@ -274,7 +274,7 @@ class Cluster(WarningMessagesMixin):
     def _get_hash_from_node_config(node_config: NodeConfigData) -> str:
         return hashlib.md5(node_config.json().encode()).hexdigest()
 
-    async def _on_node_stop(self, node: ClusterNode) -> None:
+    def _on_node_stop(self, node: ClusterNode) -> None:
         non_terminated_nodes = self.get_non_terminated_nodes()
         if not non_terminated_nodes:
             logger.debug("No more nodes running on the cluster, scheduling cluster stop")
@@ -283,7 +283,9 @@ class Cluster(WarningMessagesMixin):
                 self.stop(),
                 trace_id=get_trace_id_name(self, "on-node-stop-cluster-stop"),
             )
-        elif not any(node.manager_stack == n.manager_stack for n in self.get_non_terminated_nodes()):
+        elif not any(
+            node.manager_stack == n.manager_stack for n in self.get_non_terminated_nodes()
+        ):
             logger.debug(
                 "No more nodes running on the manager stack, scheduling manager stack stop"
             )
@@ -295,4 +297,6 @@ class Cluster(WarningMessagesMixin):
                 trace_id=get_trace_id_name(self, "on-node-stop-manager-stack-stop"),
             )
         else:
-            logger.debug("Cluster and manager stack have some nodes still running, nothing to stop.")
+            logger.debug(
+                "Cluster and manager stack have some nodes still running, nothing to stop."
+            )

--- a/ray_on_golem/server/cluster/cluster.py
+++ b/ray_on_golem/server/cluster/cluster.py
@@ -1,5 +1,4 @@
 import asyncio
-import hashlib
 import logging
 from collections import defaultdict
 from functools import partial
@@ -269,10 +268,6 @@ class Cluster(WarningMessagesMixin):
 
     def _get_stack_key(self, node_config: NodeConfigData, is_head_node: IsHeadNode) -> StackKey:
         return (node_config.get_hash(), is_head_node)
-
-    @staticmethod
-    def _get_hash_from_node_config(node_config: NodeConfigData) -> str:
-        return hashlib.md5(node_config.json().encode()).hexdigest()
 
     def _on_node_stop(self, node: ClusterNode) -> None:
         non_terminated_nodes = self.get_non_terminated_nodes()

--- a/ray_on_golem/server/cluster/cluster.py
+++ b/ray_on_golem/server/cluster/cluster.py
@@ -268,7 +268,7 @@ class Cluster(WarningMessagesMixin):
         logger.info(f"Removing stack `%s` done", stack_key)
 
     def _get_stack_key(self, node_config: NodeConfigData, is_head_node: IsHeadNode) -> StackKey:
-        return (self._get_hash_from_node_config(node_config), is_head_node)
+        return (node_config.get_hash(), is_head_node)
 
     @staticmethod
     def _get_hash_from_node_config(node_config: NodeConfigData) -> str:

--- a/ray_on_golem/server/cluster/cluster.py
+++ b/ray_on_golem/server/cluster/cluster.py
@@ -1,10 +1,13 @@
 import asyncio
+import hashlib
 import logging
 from collections import defaultdict
 from functools import partial
-from typing import DefaultDict, Dict, Iterable, List, Mapping, Tuple, Type
+from typing import DefaultDict, Dict, Iterable, List, Mapping, Sequence, Tuple, Type
 
 from golem.managers import PaymentManager
+from golem.utils.asyncio import create_task_with_logging
+from golem.utils.logging import get_trace_id_name
 from ray.autoscaler.tags import NODE_KIND_HEAD, TAG_RAY_NODE_KIND, TAG_RAY_USER_NODE_TYPE
 
 from ray_on_golem.server import utils
@@ -17,15 +20,15 @@ from ray_on_golem.server.models import (
     ProviderParametersData,
     Tags,
 )
-from ray_on_golem.server.services.golem import (
+from ray_on_golem.server.services import (
     DriverListAllocationPaymentManager,
     GolemService,
     ManagerStack,
 )
 
 IsHeadNode = bool
-NodeType = str
-StackKey = Tuple[NodeType, IsHeadNode]
+NodeHash = str
+StackKey = Tuple[NodeHash, IsHeadNode]
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +129,7 @@ class Cluster(WarningMessagesMixin):
     def clear(self) -> None:
         """Clear the internal state of the cluster."""
 
-        if self._state == NodeState.terminated:
+        if self._state != NodeState.terminated:
             logger.info("Not clearing `%s` cluster as it's not stopped", self._name)
             return
 
@@ -134,6 +137,15 @@ class Cluster(WarningMessagesMixin):
         self._nodes_id_counter = 0
         self._manager_stacks.clear()
         self._manager_stacks_locks.clear()
+
+    def get_non_terminated_nodes(self) -> Sequence["ClusterNode"]:
+        """Return cluster nodes that are running on the cluster."""
+
+        return [
+            node
+            for node in self._nodes.values()
+            if node.state not in [NodeState.terminating, NodeState.terminated]
+        ]
 
     async def request_nodes(
         self, node_config: NodeConfigData, count: int, tags: Tags
@@ -143,12 +155,19 @@ class Cluster(WarningMessagesMixin):
         is_head_node = utils.is_head_node(tags)
         worker_type = "head" if is_head_node else "worker"
         node_type = self._get_node_type(tags)
+        stack_key = self._get_stack_key(node_config, is_head_node)
 
-        logger.info("Requesting `%s` %s node(s) of type `%s`...", count, worker_type, node_type)
+        logger.info(
+            "Requesting `%s` %s node(s) of type `%s` %s...",
+            count,
+            worker_type,
+            node_type,
+            stack_key,
+        )
 
         manager_stack = await self._get_or_create_manager_stack(
+            stack_key,
             node_config,
-            node_type,
             is_head_node,
         )
 
@@ -163,6 +182,7 @@ class Cluster(WarningMessagesMixin):
                 cluster=self,
                 golem_service=self._golem_service,
                 manager_stack=manager_stack,
+                on_stop=self._on_node_stop,
                 node_id=node_id,
                 tags=tags,
                 node_config=node_config,
@@ -173,7 +193,13 @@ class Cluster(WarningMessagesMixin):
 
             node.schedule_start()
 
-        logger.info("Requesting `%s` %s node(s) of type `%s` done", count, worker_type, node_type)
+        logger.info(
+            "Requesting `%s` %s node(s) of type `%s` %s done",
+            count,
+            worker_type,
+            node_type,
+            stack_key,
+        )
         logger.debug(f"{node_config=}")
 
         return created_node_ids
@@ -189,7 +215,6 @@ class Cluster(WarningMessagesMixin):
                 HeadClusterNode,
                 webserver_port=self._webserver_port,
                 ray_gcs_expose_port=self._provider_parameters.ray_gcs_expose_port,
-                ray_dashboard_expose_port=self._provider_parameters.ray_dashboard_expose_port,
             )
             if is_head_node
             else WorkerClusterNode
@@ -204,12 +229,10 @@ class Cluster(WarningMessagesMixin):
 
     async def _get_or_create_manager_stack(
         self,
+        stack_key: StackKey,
         node_config: NodeConfigData,
-        node_type: NodeType,
         is_head_node: IsHeadNode,
     ) -> ManagerStack:
-        stack_key = (node_type, is_head_node)
-
         async with self._manager_stacks_locks[stack_key]:
             stack = self._manager_stacks.get(stack_key)
 
@@ -243,3 +266,33 @@ class Cluster(WarningMessagesMixin):
             del self._manager_stacks_locks[stack_key]
 
         logger.info(f"Removing stack `%s` done", stack_key)
+
+    def _get_stack_key(self, node_config: NodeConfigData, is_head_node: IsHeadNode) -> StackKey:
+        return (self._get_hash_from_node_config(node_config), is_head_node)
+
+    @staticmethod
+    def _get_hash_from_node_config(node_config: NodeConfigData) -> str:
+        return hashlib.md5(node_config.json().encode()).hexdigest()
+
+    async def _on_node_stop(self, node: ClusterNode) -> None:
+        non_terminated_nodes = self.get_non_terminated_nodes()
+        if not non_terminated_nodes:
+            logger.debug("No more nodes running on the cluster, scheduling cluster stop")
+
+            create_task_with_logging(
+                self.stop(),
+                trace_id=get_trace_id_name(self, "on-node-stop-cluster-stop"),
+            )
+        elif not any(node.manager_stack == n.manager_stack for n in self.get_non_terminated_nodes()):
+            logger.debug(
+                "No more nodes running on the manager stack, scheduling manager stack stop"
+            )
+
+            stack_key = self._get_stack_key(node.node_config, isinstance(node, HeadClusterNode))
+
+            create_task_with_logging(
+                self._remove_manager_stack(stack_key),
+                trace_id=get_trace_id_name(self, "on-node-stop-manager-stack-stop"),
+            )
+        else:
+            logger.debug("Cluster and manager stack have some nodes still running, nothing to stop.")

--- a/ray_on_golem/server/models.py
+++ b/ray_on_golem/server/models.py
@@ -1,3 +1,4 @@
+import hashlib
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional
@@ -85,6 +86,9 @@ class NodeConfigData(BaseModel):
 
     class Config:
         extra = "forbid"
+
+    def get_hash(self) -> str:
+        return hashlib.md5(self.json().encode()).hexdigest()
 
 
 class ProviderParametersData(BaseModel):

--- a/ray_on_golem/server/models.py
+++ b/ray_on_golem/server/models.py
@@ -90,7 +90,6 @@ class NodeConfigData(BaseModel):
 class ProviderParametersData(BaseModel):
     webserver_port: int
     ray_gcs_expose_port: Optional[int]
-    ray_dashboard_expose_port: Optional[int]
     enable_registry_stats: bool
     payment_network: str
     payment_driver: str

--- a/ray_on_golem/server/services/ray.py
+++ b/ray_on_golem/server/services/ray.py
@@ -89,7 +89,7 @@ class RayService(WarningMessagesMixin):
     ) -> List[NodeId]:
         try:
             async with self._with_cluster_context(cluster_name) as cluster:
-                nodes = self._get_non_terminated_nodes_ids(cluster)
+                nodes = cluster.get_non_terminated_nodes()
 
             if tags_to_match is None:
                 return [node.node_id for node in nodes]
@@ -97,13 +97,6 @@ class RayService(WarningMessagesMixin):
             return [node.node_id for node in nodes if are_dicts_equal(node.tags, tags_to_match)]
         except ClusterNotFound:
             return []
-
-    def _get_non_terminated_nodes_ids(self, cluster: Cluster) -> List[ClusterNode]:
-        return [
-            node
-            for node in cluster.nodes.values()
-            if node.state not in [NodeState.terminating, NodeState.terminated]
-        ]
 
     async def is_node_running(self, cluster_name: str, node_id: NodeId) -> bool:
         async with self._with_cluster_node_context(
@@ -164,11 +157,7 @@ class RayService(WarningMessagesMixin):
             return str(priv_f.read()), str(pub_f.read())
 
     def is_any_node_running(self) -> bool:
-        for cluster in self._clusters.values():
-            if self._get_non_terminated_nodes_ids(cluster):
-                return True
-
-        return False
+        return any(cluster.get_non_terminated_nodes() for cluster in self._clusters.values())
 
     async def _get_or_create_cluster(
         self, cluster_name: str, provider_parameters: ProviderParametersData
@@ -186,9 +175,10 @@ class RayService(WarningMessagesMixin):
                     provider_parameters,
                 )
 
-                await cluster.start()
-
                 logger.info("Creating cluster `%s` done", cluster_name)
+
+            # Always try to start the cluster
+            await cluster.start()
 
             return cluster
 


### PR DESCRIPTION
What I've done:
- Added cluster or manager stack teardown on node stop
- Reintroduced hash-based manager stack to support different versions of stacks under the same name
- Fixed mistyped condition in `cluster.clean()`
- Removed excessive dashboard exposure in favor of `ray dashboard` usage
- Normalized usage of the string quotes and bool casing in yaml files